### PR TITLE
Routed swap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4007,7 +4007,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-swap"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "arbitrary",
  "arrayref",
@@ -4022,6 +4022,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
+ "spl-associated-token-account 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-math",
  "spl-token 3.2.0",
  "thiserror",

--- a/token-swap/js/cli/main.ts
+++ b/token-swap/js/cli/main.ts
@@ -7,10 +7,13 @@ import {
   withdrawAllTokenTypes,
   depositSingleTokenTypeExactAmountIn,
   withdrawSingleTokenTypeExactAmountOut,
+  createSecondTokenSwapForRouting,
+  routedSwap,
+  createAccountsAndRoutedSwapAtomic,
 } from './token-swap-test';
 
 async function main() {
-  // These test cases are designed to run sequentially and in the following order
+  //These test cases are designed to run sequentially and in the following order
   console.log('Run test: initialize pool registry');
   await initializePoolRegistry();
   console.log('Run test: createTokenSwap');
@@ -27,6 +30,17 @@ async function main() {
   await depositSingleTokenTypeExactAmountIn();
   console.log('Run test: withrdaw one exact amount out');
   await withdrawSingleTokenTypeExactAmountOut();
+
+  console.log('Re-Run test: initialize pool registry');
+  await initializePoolRegistry();
+  console.log('Re-Run test: createTokenSwap');
+  await createTokenSwap();
+  console.log('Run test: create second token swap');
+  await createSecondTokenSwapForRouting();
+  console.log('Run test: routed swap');
+  await routedSwap();
+  console.log('Success\n');
+  await createAccountsAndRoutedSwapAtomic();
   console.log('Success\n');
 }
 

--- a/token-swap/js/cli/token-swap-test.ts
+++ b/token-swap/js/cli/token-swap-test.ts
@@ -32,6 +32,18 @@ let mintB: Token;
 let tokenAccountA: PublicKey;
 let tokenAccountB: PublicKey;
 
+//for routed swaps, a second swap and a third mint
+let tokenSwap2: TokenSwap;
+let authority2: PublicKey;
+let nonce2: number;
+let mintC: Token;
+let tokenAccountB2: PublicKey;
+let tokenAccountC: PublicKey;
+
+let tokenPool2: Token;
+let tokenAccountPool2: PublicKey;
+let feeAccount2: PublicKey;
+
 let payer: Keypair;
 
 // Hard-coded fee address, for testing production mode
@@ -52,6 +64,8 @@ const CURVE_TYPE = CurveType.ConstantProduct;
 // Initial amount in each swap token
 let currentSwapTokenA = 1000000;
 let currentSwapTokenB = 1000000;
+let currentSwapTokenB2 = 1000000;
+let currentSwapTokenC = 1000000;
 let currentFeeAmount = 0;
 
 // Swap instruction constants
@@ -59,8 +73,15 @@ let currentFeeAmount = 0;
 // need to get slightly tweaked in the two cases.
 const SWAP_AMOUNT_IN = 100000;
 const SWAP_AMOUNT_OUT = SWAP_PROGRAM_OWNER_FEE_ADDRESS ? 90661 : 90674;
+
 const SWAP_FEE = SWAP_PROGRAM_OWNER_FEE_ADDRESS ? 22273 : 22277;
 const OWNER_SWAP_FEE = SWAP_FEE;
+
+const ROUTED_SWAP_AMOUNT_OUT1 = SWAP_PROGRAM_OWNER_FEE_ADDRESS ? /*?*/0 : 90677;
+const ROUTED_SWAP_AMOUNT_OUT2 = SWAP_PROGRAM_OWNER_FEE_ADDRESS ? /*?*/0 : 82925;
+
+const OWNER_ROUTED_SWAP_FEE1 = SWAP_PROGRAM_OWNER_FEE_ADDRESS ? /*?*/0 : 13182;
+const OWNER_ROUTED_SWAP_FEE2 = SWAP_PROGRAM_OWNER_FEE_ADDRESS ? /*?*/0 : 11920;
 
 // Pool token amount minted on init
 const DEFAULT_POOL_TOKEN_AMOUNT = 1000000000;
@@ -86,6 +107,14 @@ async function getConnection(): Promise<Connection> {
 }
 
 export async function initializePoolRegistry(): Promise<void> {
+
+  //reset these - to allow for rerun
+  currentSwapTokenA = 1000000;
+  currentSwapTokenB = 1000000;
+  currentSwapTokenB2 = 1000000;
+  currentSwapTokenC = 1000000;
+  currentFeeAmount = 0;
+
   const connection = await getConnection();
   payer = await newAccountWithLamports(connection, 172981613440);
   const transaction = await TokenSwap.initializePoolRegistry(connection, payer.publicKey, STEP_SWAP_PROGRAM_ID)
@@ -389,6 +418,93 @@ export async function tryCreateTokenSwap(curveType: number): Promise<boolean> {
   return false;
 }
 
+export async function createSecondTokenSwapForRouting(): Promise<void> {
+  const connection = await getConnection();
+
+  console.log('creating token C');
+  mintC = await Token.createMint(
+    connection,
+    payer,
+    owner.publicKey,
+    null,
+    2,
+    TOKEN_PROGRAM_ID,
+  );
+
+  const seedKeyVec = [mintB.publicKey.toBuffer(), mintC.publicKey.toBuffer()];
+  seedKeyVec.sort();
+
+  const curveBuffer = Buffer.alloc(1);
+  curveBuffer.writeUInt8(CURVE_TYPE, 0);
+  let [tokenSwapKey, poolNonce] = await PublicKey.findProgramAddress(
+    [
+      seedKeyVec[0],
+      seedKeyVec[1],
+      curveBuffer
+    ],
+    STEP_SWAP_PROGRAM_ID,
+  );
+
+  [authority2, nonce2] = await PublicKey.findProgramAddress(
+    [tokenSwapKey.toBuffer()],
+    STEP_SWAP_PROGRAM_ID,
+  );
+
+  console.log('creating pool mint');
+  tokenPool2 = await Token.createMint(
+    connection,
+    payer,
+    authority2,
+    null,
+    2,
+    TOKEN_PROGRAM_ID,
+  );
+
+  console.log('creating pool account');
+  tokenAccountPool2 = await tokenPool2.createAccount(owner.publicKey);
+  const ownerKey = SWAP_PROGRAM_OWNER_FEE_ADDRESS || owner.publicKey.toString();
+  feeAccount2 = await tokenPool2.createAccount(new PublicKey(ownerKey));
+
+  console.log('creating token B account');
+  tokenAccountB2 = await mintB.createAccount(authority2);
+  console.log('minting token B to swap');
+  await mintB.mintTo(tokenAccountB2, owner, [], currentSwapTokenB2);
+
+  console.log('creating token C account');
+  tokenAccountC = await mintC.createAccount(authority2);
+  console.log('minting token C to swap');
+  await mintC.mintTo(tokenAccountC, owner, [], currentSwapTokenC);
+
+  const poolRegistryKey = await PublicKey.createWithSeed(payer.publicKey, POOL_REGISTRY_SEED, STEP_SWAP_PROGRAM_ID);
+
+  console.log('creating token swap');
+  tokenSwap2 = await TokenSwap.createTokenSwap(
+    connection,
+    owner,
+    tokenSwapKey,
+    authority2,
+    tokenAccountB2,
+    tokenAccountC,
+    tokenPool2.publicKey,
+    mintB.publicKey,
+    mintC.publicKey,
+    feeAccount2,
+    tokenAccountPool2,
+    STEP_SWAP_PROGRAM_ID,
+    TOKEN_PROGRAM_ID,
+    nonce2,
+    TRADING_FEE_NUMERATOR,
+    TRADING_FEE_DENOMINATOR,
+    OWNER_TRADING_FEE_NUMERATOR,
+    OWNER_TRADING_FEE_DENOMINATOR,
+    OWNER_WITHDRAW_FEE_NUMERATOR,
+    OWNER_WITHDRAW_FEE_DENOMINATOR,
+    CURVE_TYPE,
+    poolRegistryKey,
+    poolNonce
+  );
+}
+
 export async function depositAllTokenTypes(): Promise<void> {
   const poolMintInfo = await tokenPool.getMintInfo();
   const supply = poolMintInfo.supply.toNumber();
@@ -646,6 +762,214 @@ export async function swap(): Promise<void> {
 
   info = await tokenPool.getAccountInfo(feeAccount);
   assert(info.amount.toNumber() == currentFeeAmount + OWNER_SWAP_FEE);
+}
+
+export async function routedSwap(): Promise<void> {
+  console.log('Creating swap token a account');
+  let userAccountA = await mintA.createAccount(owner.publicKey);
+  await mintA.mintTo(userAccountA, owner, [], SWAP_AMOUNT_IN);
+  const userTransferAuthority = Keypair.generate();
+  await mintA.approve(
+    userAccountA,
+    userTransferAuthority.publicKey,
+    owner,
+    [],
+    SWAP_AMOUNT_IN,
+  );
+  console.log('Creating swap token b account');
+  let userAccountB = await mintB.createAccount(userTransferAuthority.publicKey);
+  console.log('Creating swap token c account');
+  let userAccountC = await mintC.createAccount(owner.publicKey);
+
+  console.log('Swapping');
+  await tokenSwap.routedSwap(
+    userAccountA,
+    tokenAccountA,
+    tokenAccountB,
+    userAccountB,
+    tokenAccountB2,
+    tokenAccountC,
+    userAccountC,
+    userTransferAuthority,
+    tokenSwap2,
+    SWAP_AMOUNT_IN, 
+    ROUTED_SWAP_AMOUNT_OUT2,
+  );
+
+  await sleep(500);
+
+  let info;
+  info = await mintA.getAccountInfo(userAccountA);
+  assert(info.amount.toNumber() == 0);
+
+  info = await mintB.getAccountInfo(userAccountB);
+  assert(info.amount.toNumber() == 0);
+
+  info = await mintC.getAccountInfo(userAccountC);
+  console.log("ROUTED_SWAP_AMOUNT_OUT2",info.amount.toNumber());
+  assert(info.amount.toNumber() == ROUTED_SWAP_AMOUNT_OUT2);
+
+  info = await mintA.getAccountInfo(tokenAccountA);
+  assert(info.amount.toNumber() == currentSwapTokenA + SWAP_AMOUNT_IN);
+  currentSwapTokenA += SWAP_AMOUNT_IN;
+
+  info = await mintB.getAccountInfo(tokenAccountB);
+  assert(info.amount.toNumber() == currentSwapTokenB - ROUTED_SWAP_AMOUNT_OUT1);
+  currentSwapTokenB -= ROUTED_SWAP_AMOUNT_OUT1;
+
+  info = await mintB.getAccountInfo(tokenAccountB2);
+  console.log("ROUTED_SWAP_AMOUNT_OUT1",info.amount.toNumber()-currentSwapTokenB2);
+  assert(info.amount.toNumber() == currentSwapTokenB2 + ROUTED_SWAP_AMOUNT_OUT1);
+  currentSwapTokenB2 += ROUTED_SWAP_AMOUNT_OUT1;
+
+  info = await mintC.getAccountInfo(tokenAccountC);
+  assert(info.amount.toNumber() == currentSwapTokenC - ROUTED_SWAP_AMOUNT_OUT2);
+  currentSwapTokenC -= ROUTED_SWAP_AMOUNT_OUT2;
+
+  info = await tokenPool.getAccountInfo(feeAccount);
+  assert(info.amount.toNumber() == OWNER_ROUTED_SWAP_FEE1);
+
+  info = await tokenPool2.getAccountInfo(feeAccount2);
+  assert(info.amount.toNumber() == OWNER_ROUTED_SWAP_FEE2);
+}
+
+//similar to the other "all-in-one" test, this test has no assertions
+//it can be referred to as best practice for doing a routed swap.
+export async function createAccountsAndRoutedSwapAtomic(): Promise<void> {
+  console.log('Creating swap token a account');
+  let userAccountA = await mintA.createAccount(owner.publicKey);
+  await mintA.mintTo(userAccountA, owner, [], SWAP_AMOUNT_IN);
+
+  // @ts-ignore
+  const balanceNeeded = await Token.getMinBalanceRentForExemptAccount(
+    connection,
+  );
+  
+  //use a temp account for the middle(B) token, even if user already has some, this is safest
+  const newAccountB = Keypair.generate();
+  
+  //find ata address for C
+  let newAccountC = await Token.getAssociatedTokenAddress(
+    mintC.associatedProgramId, 
+    mintC.programId, 
+    mintC.publicKey, 
+    owner.publicKey,
+  );
+
+  const transaction = new Transaction();
+
+  //create temp account for token B
+  transaction.add(
+    SystemProgram.createAccount({
+      fromPubkey: owner.publicKey,
+      newAccountPubkey: newAccountB.publicKey,
+      lamports: balanceNeeded,
+      space: AccountLayout.span,
+      programId: mintB.programId,
+    }),
+  );
+
+  //create a temp authority for A and B to use
+  const userTransferAuthority = Keypair.generate();
+
+  //init B token account, assign to temp authority
+  transaction.add(
+    Token.createInitAccountInstruction(
+      mintB.programId,
+      mintB.publicKey,
+      newAccountB.publicKey,
+      userTransferAuthority.publicKey,
+    ),
+  );
+
+  //init ATA for token C
+  transaction.add(
+    Token.createAssociatedTokenAccountInstruction(
+      mintC.associatedProgramId,
+      mintC.programId,
+      mintC.publicKey,
+      newAccountC,
+      owner.publicKey,
+      owner.publicKey,
+    ),
+  );
+
+  //temp authority to spend token A from owner wallet
+  transaction.add(
+    Token.createApproveInstruction(
+      mintA.programId,
+      userAccountA,
+      userTransferAuthority.publicKey,
+      owner.publicKey,
+      [owner],
+      SWAP_AMOUNT_IN,
+    ),
+  );
+
+  //swap
+  transaction.add(
+    TokenSwap.routedSwapInstruction(
+      tokenSwap.tokenSwap,
+      tokenSwap.authority,
+      userTransferAuthority.publicKey,
+      userAccountA,
+      tokenSwap.tokenAccountA,
+      tokenSwap.tokenAccountB,
+      newAccountB.publicKey,
+      tokenSwap.poolToken,
+      tokenSwap.feeAccount,
+      tokenSwap2.tokenSwap,
+      tokenSwap2.authority,
+      tokenSwap2.tokenAccountA,
+      tokenSwap2.tokenAccountB,
+      newAccountC,
+      tokenSwap2.poolToken,
+      tokenSwap2.feeAccount,
+      tokenSwap.swapProgramId,
+      tokenSwap.tokenProgramId,
+      SWAP_AMOUNT_IN,
+      0,  //apps should set this for sure, but in this test can't be ROUTED_SWAP_AMOUNT_OUT anymore because we already swapped some
+    ),
+  );
+
+  //close the middle(B) account we created for the routing
+  transaction.add(
+    Token.createCloseAccountInstruction(
+      mintB.programId,
+      newAccountB.publicKey,
+      owner.publicKey,
+      userTransferAuthority.publicKey,
+      [userTransferAuthority],
+    ),
+  );
+
+  console.log("before swap");
+  console.log("userAccountA", (await mintA.getAccountInfo(userAccountA)).amount.toNumber());
+
+  // Send the instructions
+  console.log('sending biggest instruction');
+  await sendAndConfirmTransaction(
+    'create accounts, approve transfer, swap, cleanup',
+    connection,
+    transaction,
+    owner,
+    newAccountB,
+    userTransferAuthority,
+  );
+
+  console.log("after swap");
+  console.log("userAccountA", (await mintA.getAccountInfo(userAccountA)).amount.toNumber());
+  console.log("newAccountC", (await mintC.getAccountInfo(newAccountC)).amount.toNumber());
+
+
+
+  let info;
+  info = await mintA.getAccountInfo(tokenAccountA);
+  currentSwapTokenA = info.amount.toNumber();
+  info = await mintB.getAccountInfo(tokenAccountB);
+  currentSwapTokenB = info.amount.toNumber();
+  info = await mintC.getAccountInfo(tokenAccountC);
+  currentSwapTokenC = info.amount.toNumber();
 }
 
 function tradingTokensToPoolTokens(

--- a/token-swap/program/Cargo.toml
+++ b/token-swap/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-token-swap"
-version = "2.2.0"
+version = "2.3.0"
 description = "Solana Program Library Token Swap"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"
@@ -29,6 +29,7 @@ roots = { version = "0.0.7", optional = true }
 
 [dev-dependencies]
 solana-program-test = "1.7.7"
+spl-associated-token-account = { version = "1.0.3", features = ["no-entrypoint"] }
 solana-sdk = "1.7.7"
 proptest = "1.0"
 sim =  { path = "./sim" }

--- a/token-swap/program/src/constraints.rs
+++ b/token-swap/program/src/constraints.rs
@@ -62,7 +62,7 @@ impl<'a> SwapConstraints<'a> {
 const OWNER_KEY: &str = env!("SWAP_PROGRAM_OWNER_FEE_ADDRESS");
 #[cfg(feature = "production")]
 const FEES: &Fees = &Fees {
-    trade_fee_numerator: 0,
+    trade_fee_numerator: 20,
     trade_fee_denominator: 10000,
     owner_trade_fee_numerator: 10,
     owner_trade_fee_denominator: 10000,

--- a/token-swap/program/src/processor.rs
+++ b/token-swap/program/src/processor.rs
@@ -392,9 +392,9 @@ impl Processor {
         minimum_amount_out: u64,
         accounts: &[AccountInfo],
     ) -> ProgramResult {
-        //we cut the owner fees when routing through pools by 2/3 each
-        const ROUTED_OWNER_FEE_NUMERATOR_MULT: u64 = 2;
-        const ROUTED_OWNER_FEE_DENOMINATOR_MULT: u64 = 3;
+        //we cut the owner fees when routing through pools 
+        const ROUTED_OWNER_FEE_NUMERATOR_MULT: u64 = 1;
+        const ROUTED_OWNER_FEE_DENOMINATOR_MULT: u64 = 2;
         
         let account_info_iter = &mut accounts.iter();
         let swap_info = next_account_info(account_info_iter)?;

--- a/token-swap/program/src/processor.rs
+++ b/token-swap/program/src/processor.rs
@@ -426,13 +426,14 @@ impl Processor {
         
         //second swap
 
-        let swap_info2 = next_account_info(account_info_iter)?;
-        let authority_info2 = next_account_info(account_info_iter)?;
-        let swap_source_info2 = next_account_info(account_info_iter)?;
-        let swap_destination_info2 = next_account_info(account_info_iter)?;
-        let destination_info2 = next_account_info(account_info_iter)?;
-        let pool_mint_info2 = next_account_info(account_info_iter)?;
-        let pool_fee_account_info2 = next_account_info(account_info_iter)?;
+        let swap_info = next_account_info(account_info_iter)?;
+        let authority_info = next_account_info(account_info_iter)?;
+        let source_info = destination_info; //source is prior destination
+        let swap_source_info = next_account_info(account_info_iter)?;
+        let swap_destination_info = next_account_info(account_info_iter)?;
+        let destination_info = next_account_info(account_info_iter)?;
+        let pool_mint_info = next_account_info(account_info_iter)?;
+        let pool_fee_account_info = next_account_info(account_info_iter)?;
 
         let swap_result2 = Self::process_swap_internal(
             program_id,
@@ -440,15 +441,15 @@ impl Processor {
             swap_result1.destination_amount_swapped.try_into().unwrap(),
             //this is where the slippage checks would take hold
             minimum_amount_out,
-            swap_info2,
-            authority_info2,
+            swap_info,
+            authority_info,
             user_transfer_authority_info,
-            destination_info, //source is prior destination
-            swap_source_info2,
-            swap_destination_info2,
-            destination_info2,
-            pool_mint_info2,
-            pool_fee_account_info2,
+            source_info, 
+            swap_source_info,
+            swap_destination_info,
+            destination_info,
+            pool_mint_info,
+            pool_fee_account_info,
             token_program_info,
         )?;
 

--- a/token-swap/program/src/processor.rs
+++ b/token-swap/program/src/processor.rs
@@ -393,8 +393,8 @@ impl Processor {
         accounts: &[AccountInfo],
     ) -> ProgramResult {
         //we cut the owner fees when routing through pools 
-        const ROUTED_OWNER_FEE_NUMERATOR_MULT: u64 = 1;
-        const ROUTED_OWNER_FEE_DENOMINATOR_MULT: u64 = 2;
+        const ROUTED_OWNER_FEE_NUMERATOR_MULT: u64 = 6;
+        const ROUTED_OWNER_FEE_DENOMINATOR_MULT: u64 = 10;
         
         let account_info_iter = &mut accounts.iter();
         let swap_info = next_account_info(account_info_iter)?;
@@ -1284,7 +1284,7 @@ impl Processor {
                 amount_in,
                 minimum_amount_out,
             }) => {
-                msg!("Instruction: DualSwap");
+                msg!("Instruction: RoutedSwap");
                 Self::process_routed_swap(program_id, amount_in, minimum_amount_out, accounts)
             }
         }

--- a/token-swap/program/tests/deposit.rs
+++ b/token-swap/program/tests/deposit.rs
@@ -35,12 +35,17 @@ async fn fn_test_deposit_swap_not_init() {
     );
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
+    let mint_a = Keypair::new();
+    let mint_b = Keypair::new();
     let token_a_amount = 1000;
     let token_b_amount = 9000;
     let mut swap = helpers::create_standard_setup(
         &mut banks_client,
         &payer,
         &recent_blockhash,
+        None,
+        &mint_a, 
+        &mint_b,
         token_a_amount,
         token_b_amount,
     )

--- a/token-swap/program/tests/dual_swap.rs
+++ b/token-swap/program/tests/dual_swap.rs
@@ -15,6 +15,17 @@ use {
     spl_token_swap::error::SwapError,
 };
 
+const POOL_TOKEN_A_AMOUNT: u64 = 700_000_000_000_000;
+const POOL_TOKEN_B_AMOUNT: u64 = 600_000_000_000_000;
+const POOL_TOKEN_B2_AMOUNT: u64 = 300_000_000_000_000;
+const POOL_TOKEN_C_AMOUNT: u64 = 400_000_000_000_000;
+const USER_TOKEN_A_BAL: u64 = 200_000;
+const USER_WILL_SWAP: u64 = 100_000;
+const USER_WILL_EXPECT: u64 = 114_286;
+//const USER_WILL_RECEIVE: u64 = 112_463;
+//if router discount used fees
+const USER_WILL_RECEIVE: u64 = 112_691;
+
 #[tokio::test]
 async fn fn_dual_swap_create_b_c() {
     let user = Keypair::new();
@@ -32,9 +43,6 @@ async fn fn_dual_swap_create_b_c() {
     let token_c_mint_key = Keypair::new();
 
     //lp1
-    let token_a_amount = 700_000_000_000_000;
-    let token_b_amount = 600_000_000_000_000;
-
     let mut swap1 = helpers::create_standard_setup(
         &mut banks_client,
         &payer,
@@ -42,8 +50,8 @@ async fn fn_dual_swap_create_b_c() {
         None,
         &token_a_mint_key,
         &token_b_mint_key,
-        token_a_amount,
-        token_b_amount,
+        POOL_TOKEN_A_AMOUNT,
+        POOL_TOKEN_B_AMOUNT,
     )
     .await;
     swap1
@@ -52,9 +60,6 @@ async fn fn_dual_swap_create_b_c() {
         .unwrap();
 
     //lp2
-    let token_b2_amount = 300_000_000_000_000;
-    let token_c_amount = 400_000_000_000_000;
-
     let mut swap2 = helpers::create_standard_setup(
         &mut banks_client,
         &payer,
@@ -64,20 +69,21 @@ async fn fn_dual_swap_create_b_c() {
         //use the same mint as the right side of swap1
         &token_b_mint_key,
         &token_c_mint_key,
-        token_b2_amount,
-        token_c_amount,
+        POOL_TOKEN_B2_AMOUNT,
+        POOL_TOKEN_C_AMOUNT,
     )
     .await;
     swap2
         .initialize_swap(&mut banks_client, &payer, &recent_blockhash)
         .await
         .unwrap();
+
     //our test swap will be
     //100,000 A in -> 85,714 B -> 114,286 C out (excluding fees)
-    let amount_user_will_have: u64 = 200_000;
-    let amount_user_will_swap: u64 = 100_000;
-    let mut amount_user_expects: u64 = 114_286;
-    let amount_user_actually_gets: u64 = 112_463; //after fees
+    let amount_user_will_have: u64 = USER_TOKEN_A_BAL;
+    let amount_user_will_swap: u64 = USER_WILL_SWAP;
+    let mut amount_user_expects: u64 = USER_WILL_EXPECT;
+    let amount_user_actually_gets: u64 = USER_WILL_RECEIVE; //after fees
 
     //setup our users token account, owned and paid for by user
     let user_token_a = Keypair::new();
@@ -194,11 +200,8 @@ async fn fn_dual_swap_create_b() {
     let token_a_mint_key = Keypair::new();
     let token_b_mint_key = Keypair::new();
     let token_c_mint_key = Keypair::new();
-
+    
     //lp1
-    let token_a_amount = 700_000_000_000_000;
-    let token_b_amount = 600_000_000_000_000;
-
     let mut swap1 = helpers::create_standard_setup(
         &mut banks_client,
         &payer,
@@ -206,8 +209,8 @@ async fn fn_dual_swap_create_b() {
         None,
         &token_a_mint_key,
         &token_b_mint_key,
-        token_a_amount,
-        token_b_amount,
+        POOL_TOKEN_A_AMOUNT,
+        POOL_TOKEN_B_AMOUNT,
     )
     .await;
     swap1
@@ -216,9 +219,6 @@ async fn fn_dual_swap_create_b() {
         .unwrap();
 
     //lp2
-    let token_b2_amount = 300_000_000_000_000;
-    let token_c_amount = 400_000_000_000_000;
-
     let mut swap2 = helpers::create_standard_setup(
         &mut banks_client,
         &payer,
@@ -228,20 +228,21 @@ async fn fn_dual_swap_create_b() {
         //use the same mint as the right side of swap1
         &token_b_mint_key,
         &token_c_mint_key,
-        token_b2_amount,
-        token_c_amount,
+        POOL_TOKEN_B2_AMOUNT,
+        POOL_TOKEN_C_AMOUNT,
     )
     .await;
     swap2
         .initialize_swap(&mut banks_client, &payer, &recent_blockhash)
         .await
         .unwrap();
+
     //our test swap will be
     //100,000 A in -> 85,714 B -> 114,286 C out (excluding fees)
-    let amount_user_will_have: u64 = 200_000;
-    let amount_user_will_swap: u64 = 100_000;
-    let mut amount_user_expects: u64 = 114_286;
-    let amount_user_actually_gets: u64 = 112_463; //after fees
+    let amount_user_will_have: u64 = USER_TOKEN_A_BAL;
+    let amount_user_will_swap: u64 = USER_WILL_SWAP;
+    let mut amount_user_expects: u64 = USER_WILL_EXPECT;
+    let amount_user_actually_gets: u64 = USER_WILL_RECEIVE; //after fees
 
     //setup our users token account, owned and paid for by user
     let user_token_a = Keypair::new();
@@ -341,9 +342,6 @@ async fn fn_dual_swap_reuse_all() {
     let token_c_mint_key = Keypair::new();
 
     //lp1
-    let token_a_amount = 700_000_000_000_000;
-    let token_b_amount = 600_000_000_000_000;
-
     let mut swap1 = helpers::create_standard_setup(
         &mut banks_client,
         &payer,
@@ -351,8 +349,8 @@ async fn fn_dual_swap_reuse_all() {
         None,
         &token_a_mint_key,
         &token_b_mint_key,
-        token_a_amount,
-        token_b_amount,
+        POOL_TOKEN_A_AMOUNT,
+        POOL_TOKEN_B_AMOUNT,
     )
     .await;
     swap1
@@ -361,9 +359,6 @@ async fn fn_dual_swap_reuse_all() {
         .unwrap();
 
     //lp2
-    let token_b2_amount = 300_000_000_000_000;
-    let token_c_amount = 400_000_000_000_000;
-
     let mut swap2 = helpers::create_standard_setup(
         &mut banks_client,
         &payer,
@@ -373,22 +368,23 @@ async fn fn_dual_swap_reuse_all() {
         //use the same mint as the right side of swap1
         &token_b_mint_key,
         &token_c_mint_key,
-        token_b2_amount,
-        token_c_amount,
+        POOL_TOKEN_B2_AMOUNT,
+        POOL_TOKEN_C_AMOUNT,
     )
     .await;
     swap2
         .initialize_swap(&mut banks_client, &payer, &recent_blockhash)
         .await
         .unwrap();
+        
     //our test swap will be
     //100,000 A in -> 85,714 B -> 114,286 C out (excluding fees)
     let amount_user_had_token_b: u64 = 999_234_432;
     let amount_user_had_token_c: u64 = 123_345_345;
-    let amount_user_will_have: u64 = 200_000;
-    let amount_user_will_swap: u64 = 100_000;
-    let mut amount_user_expects: u64 = 114_286;
-    let amount_user_actually_gets: u64 = 112_463; //after fees
+    let amount_user_will_have: u64 = USER_TOKEN_A_BAL;
+    let amount_user_will_swap: u64 = USER_WILL_SWAP;
+    let mut amount_user_expects: u64 = USER_WILL_EXPECT;
+    let amount_user_actually_gets: u64 = USER_WILL_RECEIVE; //after fees
 
     //setup our users token account, owned and paid for by user
     let user_token_a = Keypair::new();

--- a/token-swap/program/tests/dual_swap.rs
+++ b/token-swap/program/tests/dual_swap.rs
@@ -3,32 +3,27 @@
 mod helpers;
 
 use {
-    solana_program_test::{tokio},
+    solana_program_test::tokio,
     solana_sdk::{
+        account::Account,
         instruction::InstructionError,
         signature::{Keypair, Signer},
+        system_program,
         transaction::TransactionError,
         transport::TransportError,
-        account::Account,
-        system_program,
     },
-    spl_token_swap::{
-        curve::{
-            calculator::INITIAL_SWAP_POOL_AMOUNT,
-        },
-    },
-    std::convert::TryInto,
+    spl_token_swap::error::SwapError,
 };
 
 #[tokio::test]
-async fn fn_dual_swap() {
+async fn fn_dual_swap_create_b_c() {
     let user = Keypair::new();
 
     let mut pt = helpers::program_test();
     //throw our user account directly onto the chain startup
     pt.add_account(
-        user.pubkey(), 
-        Account::new(100_000_000_000, 0, &system_program::id())
+        user.pubkey(),
+        Account::new(100_000_000_000, 0, &system_program::id()),
     );
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
@@ -37,8 +32,8 @@ async fn fn_dual_swap() {
     let token_c_mint_key = Keypair::new();
 
     //lp1
-    let token_a_amount = 600_000_000_000_000;
-    let token_b_amount = 500_000_000_000_000;
+    let token_a_amount = 700_000_000_000_000;
+    let token_b_amount = 600_000_000_000_000;
 
     let mut swap1 = helpers::create_standard_setup(
         &mut banks_client,
@@ -51,13 +46,14 @@ async fn fn_dual_swap() {
         token_b_amount,
     )
     .await;
-    swap1.initialize_swap(&mut banks_client, &payer, &recent_blockhash)
+    swap1
+        .initialize_swap(&mut banks_client, &payer, &recent_blockhash)
         .await
         .unwrap();
 
     //lp2
-    let token_b2_amount = 400_000_000_000_000;
-    let token_c_amount = 300_000_000_000_000;
+    let token_b2_amount = 300_000_000_000_000;
+    let token_c_amount = 400_000_000_000_000;
 
     let mut swap2 = helpers::create_standard_setup(
         &mut banks_client,
@@ -72,12 +68,16 @@ async fn fn_dual_swap() {
         token_c_amount,
     )
     .await;
-    swap2.initialize_swap(&mut banks_client, &payer, &recent_blockhash)
+    swap2
+        .initialize_swap(&mut banks_client, &payer, &recent_blockhash)
         .await
         .unwrap();
-
-    let amount_user_will_swap: u64 = 1_000_000_000;
-    let amount_user_expects: u64 = 1_000_000_000;
+    //our test swap will be
+    //100,000 A in -> 85,714 B -> 114,286 C out (excluding fees)
+    let amount_user_will_have: u64 = 200_000;
+    let amount_user_will_swap: u64 = 100_000;
+    let mut amount_user_expects: u64 = 114_286;
+    let amount_user_actually_gets: u64 = 112_463; //after fees
 
     //setup our users token account, owned and paid for by user
     let user_token_a = Keypair::new();
@@ -99,77 +99,404 @@ async fn fn_dual_swap() {
         &swap1.token_a_mint_key.pubkey(),
         &user_token_a.pubkey(),
         &payer,
-        amount_user_will_swap,
+        amount_user_will_have,
     )
     .await
     .unwrap();
 
-    
-    /*** now our user does a swap */
+    //swap without a high enough slippage
+    {
+        //swap ins
+        let transaction_error = swap1
+            .routed_swap(
+                &mut banks_client,
+                &user,
+                &recent_blockhash,
+                &swap2,
+                &user_token_a.pubkey(),
+                None,
+                None,
+                amount_user_will_swap,
+                amount_user_expects,
+            )
+            .await
+            .err()
+            .unwrap();
+
+        if let TransportError::TransactionError(TransactionError::InstructionError(
+            _,
+            InstructionError::Custom(err),
+        )) = transaction_error
+        {
+            if err as u32 != SwapError::ExceededSlippage as u32 {
+                panic!("Did not find the expected failure due to slippage (received other error)")
+            }
+        } else {
+            panic!("Did not find the expected failure due to slippage")
+        }
+    }
+
+    //allow it some slippage
+    amount_user_expects = amount_user_expects 
+        - (amount_user_expects as f32 * 0.016) as u64; //fees - 0.5% trade, 0.3% owner. * 2 for 2 pools
+        -(amount_user_expects as f32 * 0.005) as u64; //0.5% slippage
+
+    {
+    swap1
+        .routed_swap(
+            &mut banks_client,
+            &user,
+            &recent_blockhash,
+            &swap2,
+            &user_token_a.pubkey(),
+            None,
+            None,
+            amount_user_will_swap,
+            amount_user_expects,
+        )
+        .await
+        .unwrap();
+    }
+
+
+    //verify balances
+    let user_token_c = spl_associated_token_account::get_associated_token_address(
+        &user.pubkey(), 
+        &token_c_mint_key.pubkey(),
+    );
+
+    let user_token_a_bal = helpers::get_token_balance(&mut banks_client, &user_token_a.pubkey()).await;
+    assert_eq!(user_token_a_bal, amount_user_will_have - amount_user_will_swap);
+    let user_token_c_bal = helpers::get_token_balance(&mut banks_client, &user_token_c).await;
+    assert_eq!(user_token_c_bal, amount_user_actually_gets);
+
+    //verify b account doesnt exist
+    let user_token_b = spl_associated_token_account::get_associated_token_address(
+        &user.pubkey(), 
+        &token_b_mint_key.pubkey(),
+    );
+    let is = banks_client.get_account(user_token_b).await.unwrap();
+    assert_eq!(is, None);
+}
+
+#[tokio::test]
+async fn fn_dual_swap_create_b() {
+    let user = Keypair::new();
+
+    let mut pt = helpers::program_test();
+    //throw our user account directly onto the chain startup
+    pt.add_account(
+        user.pubkey(),
+        Account::new(100_000_000_000, 0, &system_program::id()),
+    );
+    let (mut banks_client, payer, recent_blockhash) = pt.start().await;
+
+    let token_a_mint_key = Keypair::new();
+    let token_b_mint_key = Keypair::new();
+    let token_c_mint_key = Keypair::new();
+
+    //lp1
+    let token_a_amount = 700_000_000_000_000;
+    let token_b_amount = 600_000_000_000_000;
+
+    let mut swap1 = helpers::create_standard_setup(
+        &mut banks_client,
+        &payer,
+        &recent_blockhash,
+        None,
+        &token_a_mint_key,
+        &token_b_mint_key,
+        token_a_amount,
+        token_b_amount,
+    )
+    .await;
+    swap1
+        .initialize_swap(&mut banks_client, &payer, &recent_blockhash)
+        .await
+        .unwrap();
+
+    //lp2
+    let token_b2_amount = 300_000_000_000_000;
+    let token_c_amount = 400_000_000_000_000;
+
+    let mut swap2 = helpers::create_standard_setup(
+        &mut banks_client,
+        &payer,
+        &recent_blockhash,
+        //reuse same registry
+        Some(swap1.pool_registry_pubkey.clone()),
+        //use the same mint as the right side of swap1
+        &token_b_mint_key,
+        &token_c_mint_key,
+        token_b2_amount,
+        token_c_amount,
+    )
+    .await;
+    swap2
+        .initialize_swap(&mut banks_client, &payer, &recent_blockhash)
+        .await
+        .unwrap();
     //our test swap will be
-    //100,000 A in -> 180,000 B -> 77,142 C out
-    swap1.routed_swap(
+    //100,000 A in -> 85,714 B -> 114,286 C out (excluding fees)
+    let amount_user_will_have: u64 = 200_000;
+    let amount_user_will_swap: u64 = 100_000;
+    let mut amount_user_expects: u64 = 114_286;
+    let amount_user_actually_gets: u64 = 112_463; //after fees
+
+    //setup our users token account, owned and paid for by user
+    let user_token_a = Keypair::new();
+    helpers::create_token_account(
         &mut banks_client,
         &user,
         &recent_blockhash,
-        &swap2,
+        &user_token_a,
+        &swap1.token_a_mint_key.pubkey(),
+        &user.pubkey(),
+    )
+    .await
+    .unwrap();
+    //mint tokens to the users account using payer
+    helpers::mint_tokens(
+        &mut banks_client,
+        &payer,
+        &recent_blockhash,
+        &swap1.token_a_mint_key.pubkey(),
         &user_token_a.pubkey(),
-        None,
-        None,
-        amount_user_will_swap,
-        0,
+        &payer,
+        amount_user_will_have,
     )
     .await
     .unwrap();
 
+    //create token b account
+    let user_token_b = Keypair::new();
+    helpers::create_token_account(
+        &mut banks_client,
+        &user,
+        &recent_blockhash,
+        &user_token_b,
+        &swap1.token_b_mint_key.pubkey(),
+        &user.pubkey(),
+    )
+    .await
+    .unwrap();
 
-    // depositing 10% of the current pool amount in token A and B means
-    // that our pool tokens will be worth 1 / 10 of the current pool amount
-    // let pool_amount = INITIAL_SWAP_POOL_AMOUNT / 10;
-    // let deposit_a = token_a_amount / 10;
-    // let deposit_b = token_b_amount / 10;
+    //allow it some slippage
+    amount_user_expects = amount_user_expects 
+        - (amount_user_expects as f32 * 0.016) as u64; //fees - 0.5% trade, 0.3% owner. * 2 for 2 pools
+        -(amount_user_expects as f32 * 0.005) as u64; //0.5% slippage
 
-    // let token_account_a = Keypair::new();
-    // let token_account_b = Keypair::new();
-    // let token_account_pool = Keypair::new();
+    {
+    swap1
+        .routed_swap(
+            &mut banks_client,
+            &user,
+            &recent_blockhash,
+            &swap2,
+            &user_token_a.pubkey(),
+            Some(&user_token_b.pubkey()),
+            None,
+            amount_user_will_swap,
+            amount_user_expects,
+        )
+        .await
+        .unwrap();
+    }
 
-    // helpers::create_depositor(
-    //     &mut banks_client, 
-    //     &payer, 
-    //     &recent_blockhash,
-    //     &depositor,
-    //     &token_account_a,
-    //     &token_account_b,
-    //     &token_account_pool,
-    //     &swap.token_a_mint_key.pubkey(),
-    //     &swap.token_b_mint_key.pubkey(),
-    //     &swap.pool_mint_key.pubkey(),
-    //     deposit_a,
-    //     deposit_b,
-    // ).await;
 
-    // let transaction_error = swap
-    //     .deposit_all_token_types(
-    //         &mut banks_client, 
-    //         &depositor, 
-    //         &recent_blockhash,
-    //         &depositor,
-    //         &token_account_a.pubkey(),
-    //         &token_account_b.pubkey(),
-    //         &token_account_pool.pubkey(),
-    //         pool_amount.try_into().unwrap(),
-    //         deposit_a,
-    //         deposit_b,
-    //     )
-    //     .await
-    //     .err()
-    //     .unwrap();
-    // if let TransportError::TransactionError(TransactionError::InstructionError(
-    //         _,
-    //         InstructionError::InvalidAccountData, 
-    //     )) = transaction_error { }
-    // else {
-    //     panic!("Wrong error occurs while depositing into uninitialized swap")
-    // }
-    
+    //verify balances
+    let user_token_c = spl_associated_token_account::get_associated_token_address(
+        &user.pubkey(), 
+        &token_c_mint_key.pubkey(),
+    );
+
+    let user_token_a_bal = helpers::get_token_balance(&mut banks_client, &user_token_a.pubkey()).await;
+    assert_eq!(user_token_a_bal, amount_user_will_have - amount_user_will_swap);
+    let user_token_c_bal = helpers::get_token_balance(&mut banks_client, &user_token_c).await;
+    assert_eq!(user_token_c_bal, amount_user_actually_gets);
+
+    //verify b account doesnt exist anymore
+    let user_token_b = spl_associated_token_account::get_associated_token_address(
+        &user.pubkey(), 
+        &token_b_mint_key.pubkey(),
+    );
+    let is = banks_client.get_account(user_token_b).await.unwrap();
+    assert_eq!(is, None);
+}
+
+#[tokio::test]
+async fn fn_dual_swap_reuse_all() {
+    let user = Keypair::new();
+
+    let mut pt = helpers::program_test();
+    //throw our user account directly onto the chain startup
+    pt.add_account(
+        user.pubkey(),
+        Account::new(100_000_000_000, 0, &system_program::id()),
+    );
+    let (mut banks_client, payer, recent_blockhash) = pt.start().await;
+
+    let token_a_mint_key = Keypair::new();
+    let token_b_mint_key = Keypair::new();
+    let token_c_mint_key = Keypair::new();
+
+    //lp1
+    let token_a_amount = 700_000_000_000_000;
+    let token_b_amount = 600_000_000_000_000;
+
+    let mut swap1 = helpers::create_standard_setup(
+        &mut banks_client,
+        &payer,
+        &recent_blockhash,
+        None,
+        &token_a_mint_key,
+        &token_b_mint_key,
+        token_a_amount,
+        token_b_amount,
+    )
+    .await;
+    swap1
+        .initialize_swap(&mut banks_client, &payer, &recent_blockhash)
+        .await
+        .unwrap();
+
+    //lp2
+    let token_b2_amount = 300_000_000_000_000;
+    let token_c_amount = 400_000_000_000_000;
+
+    let mut swap2 = helpers::create_standard_setup(
+        &mut banks_client,
+        &payer,
+        &recent_blockhash,
+        //reuse same registry
+        Some(swap1.pool_registry_pubkey.clone()),
+        //use the same mint as the right side of swap1
+        &token_b_mint_key,
+        &token_c_mint_key,
+        token_b2_amount,
+        token_c_amount,
+    )
+    .await;
+    swap2
+        .initialize_swap(&mut banks_client, &payer, &recent_blockhash)
+        .await
+        .unwrap();
+    //our test swap will be
+    //100,000 A in -> 85,714 B -> 114,286 C out (excluding fees)
+    let amount_user_had_token_b: u64 = 999_234_432;
+    let amount_user_had_token_c: u64 = 123_345_345;
+    let amount_user_will_have: u64 = 200_000;
+    let amount_user_will_swap: u64 = 100_000;
+    let mut amount_user_expects: u64 = 114_286;
+    let amount_user_actually_gets: u64 = 112_463; //after fees
+
+    //setup our users token account, owned and paid for by user
+    let user_token_a = Keypair::new();
+    helpers::create_token_account(
+        &mut banks_client,
+        &user,
+        &recent_blockhash,
+        &user_token_a,
+        &swap1.token_a_mint_key.pubkey(),
+        &user.pubkey(),
+    )
+    .await
+    .unwrap();
+    //mint tokens to the users account using payer
+    helpers::mint_tokens(
+        &mut banks_client,
+        &payer,
+        &recent_blockhash,
+        &swap1.token_a_mint_key.pubkey(),
+        &user_token_a.pubkey(),
+        &payer,
+        amount_user_will_have,
+    )
+    .await
+    .unwrap();
+
+    //create token b account
+    let user_token_b = Keypair::new();
+    helpers::create_token_account(
+        &mut banks_client,
+        &user,
+        &recent_blockhash,
+        &user_token_b,
+        &swap1.token_b_mint_key.pubkey(),
+        &user.pubkey(),
+    )
+    .await
+    .unwrap();
+    //mint tokens to the users account using payer
+    helpers::mint_tokens(
+        &mut banks_client,
+        &payer,
+        &recent_blockhash,
+        &swap1.token_b_mint_key.pubkey(),
+        &user_token_b.pubkey(),
+        &payer,
+        amount_user_had_token_b,
+    )
+    .await
+    .unwrap();
+
+    //create token c account
+    let user_token_c = Keypair::new();
+    helpers::create_token_account(
+        &mut banks_client,
+        &user,
+        &recent_blockhash,
+        &user_token_c,
+        &swap2.token_b_mint_key.pubkey(),
+        &user.pubkey(),
+    )
+    .await
+    .unwrap();
+    //mint tokens to the users account using payer
+    helpers::mint_tokens(
+        &mut banks_client,
+        &payer,
+        &recent_blockhash,
+        &swap2.token_b_mint_key.pubkey(),
+        &user_token_c.pubkey(),
+        &payer,
+        amount_user_had_token_c,
+    )
+    .await
+    .unwrap();
+
+    //allow it some slippage
+    amount_user_expects = amount_user_expects 
+        - (amount_user_expects as f32 * 0.016) as u64; //fees - 0.5% trade, 0.3% owner. * 2 for 2 pools
+        -(amount_user_expects as f32 * 0.005) as u64; //0.5% slippage
+
+    {
+    swap1
+        .routed_swap(
+            &mut banks_client,
+            &user,
+            &recent_blockhash,
+            &swap2,
+            &user_token_a.pubkey(),
+            Some(&user_token_b.pubkey()),
+            Some(&user_token_c.pubkey()),
+            amount_user_will_swap,
+            amount_user_expects,
+        )
+        .await
+        .unwrap();
+    }
+
+
+    //assert that unswapped amount remains
+    let user_token_a_bal = helpers::get_token_balance(&mut banks_client, &user_token_a.pubkey()).await;
+    assert_eq!(user_token_a_bal, amount_user_will_have - amount_user_will_swap);
+
+
+    //assert that prior balances remain in place
+    let user_token_b_bal = helpers::get_token_balance(&mut banks_client, &user_token_b.pubkey()).await;
+    assert_eq!(user_token_b_bal, amount_user_had_token_b);
+
+    let user_token_c_bal = helpers::get_token_balance(&mut banks_client, &user_token_c.pubkey()).await;
+    assert_eq!(user_token_c_bal, amount_user_had_token_c + amount_user_actually_gets);
 }

--- a/token-swap/program/tests/dual_swap.rs
+++ b/token-swap/program/tests/dual_swap.rs
@@ -1,0 +1,175 @@
+#![cfg(feature = "test-bpf")]
+
+mod helpers;
+
+use {
+    solana_program_test::{tokio},
+    solana_sdk::{
+        instruction::InstructionError,
+        signature::{Keypair, Signer},
+        transaction::TransactionError,
+        transport::TransportError,
+        account::Account,
+        system_program,
+    },
+    spl_token_swap::{
+        curve::{
+            calculator::INITIAL_SWAP_POOL_AMOUNT,
+        },
+    },
+    std::convert::TryInto,
+};
+
+#[tokio::test]
+async fn fn_dual_swap() {
+    let user = Keypair::new();
+
+    let mut pt = helpers::program_test();
+    //throw our user account directly onto the chain startup
+    pt.add_account(
+        user.pubkey(), 
+        Account::new(100_000_000_000, 0, &system_program::id())
+    );
+    let (mut banks_client, payer, recent_blockhash) = pt.start().await;
+
+    let token_a_mint_key = Keypair::new();
+    let token_b_mint_key = Keypair::new();
+    let token_c_mint_key = Keypair::new();
+
+    //lp1
+    let token_a_amount = 600_000_000_000_000;
+    let token_b_amount = 500_000_000_000_000;
+
+    let mut swap1 = helpers::create_standard_setup(
+        &mut banks_client,
+        &payer,
+        &recent_blockhash,
+        None,
+        &token_a_mint_key,
+        &token_b_mint_key,
+        token_a_amount,
+        token_b_amount,
+    )
+    .await;
+    swap1.initialize_swap(&mut banks_client, &payer, &recent_blockhash)
+        .await
+        .unwrap();
+
+    //lp2
+    let token_b2_amount = 400_000_000_000_000;
+    let token_c_amount = 300_000_000_000_000;
+
+    let mut swap2 = helpers::create_standard_setup(
+        &mut banks_client,
+        &payer,
+        &recent_blockhash,
+        //reuse same registry
+        Some(swap1.pool_registry_pubkey.clone()),
+        //use the same mint as the right side of swap1
+        &token_b_mint_key,
+        &token_c_mint_key,
+        token_b2_amount,
+        token_c_amount,
+    )
+    .await;
+    swap2.initialize_swap(&mut banks_client, &payer, &recent_blockhash)
+        .await
+        .unwrap();
+
+    let amount_user_will_swap: u64 = 1_000_000_000;
+    let amount_user_expects: u64 = 1_000_000_000;
+
+    //setup our users token account, owned and paid for by user
+    let user_token_a = Keypair::new();
+    helpers::create_token_account(
+        &mut banks_client,
+        &user,
+        &recent_blockhash,
+        &user_token_a,
+        &swap1.token_a_mint_key.pubkey(),
+        &user.pubkey(),
+    )
+    .await
+    .unwrap();
+    //mint tokens to the users account using payer
+    helpers::mint_tokens(
+        &mut banks_client,
+        &payer,
+        &recent_blockhash,
+        &swap1.token_a_mint_key.pubkey(),
+        &user_token_a.pubkey(),
+        &payer,
+        amount_user_will_swap,
+    )
+    .await
+    .unwrap();
+
+    
+    /*** now our user does a swap */
+    //our test swap will be
+    //100,000 A in -> 180,000 B -> 77,142 C out
+    swap1.routed_swap(
+        &mut banks_client,
+        &user,
+        &recent_blockhash,
+        &swap2,
+        &user_token_a.pubkey(),
+        None,
+        None,
+        amount_user_will_swap,
+        0,
+    )
+    .await
+    .unwrap();
+
+
+    // depositing 10% of the current pool amount in token A and B means
+    // that our pool tokens will be worth 1 / 10 of the current pool amount
+    // let pool_amount = INITIAL_SWAP_POOL_AMOUNT / 10;
+    // let deposit_a = token_a_amount / 10;
+    // let deposit_b = token_b_amount / 10;
+
+    // let token_account_a = Keypair::new();
+    // let token_account_b = Keypair::new();
+    // let token_account_pool = Keypair::new();
+
+    // helpers::create_depositor(
+    //     &mut banks_client, 
+    //     &payer, 
+    //     &recent_blockhash,
+    //     &depositor,
+    //     &token_account_a,
+    //     &token_account_b,
+    //     &token_account_pool,
+    //     &swap.token_a_mint_key.pubkey(),
+    //     &swap.token_b_mint_key.pubkey(),
+    //     &swap.pool_mint_key.pubkey(),
+    //     deposit_a,
+    //     deposit_b,
+    // ).await;
+
+    // let transaction_error = swap
+    //     .deposit_all_token_types(
+    //         &mut banks_client, 
+    //         &depositor, 
+    //         &recent_blockhash,
+    //         &depositor,
+    //         &token_account_a.pubkey(),
+    //         &token_account_b.pubkey(),
+    //         &token_account_pool.pubkey(),
+    //         pool_amount.try_into().unwrap(),
+    //         deposit_a,
+    //         deposit_b,
+    //     )
+    //     .await
+    //     .err()
+    //     .unwrap();
+    // if let TransportError::TransactionError(TransactionError::InstructionError(
+    //         _,
+    //         InstructionError::InvalidAccountData, 
+    //     )) = transaction_error { }
+    // else {
+    //     panic!("Wrong error occurs while depositing into uninitialized swap")
+    // }
+    
+}

--- a/token-swap/program/tests/helpers/mod.rs
+++ b/token-swap/program/tests/helpers/mod.rs
@@ -45,10 +45,10 @@ pub async fn create_standard_setup<'a>(
         .unwrap());
 
     let fees = Fees {
-        trade_fee_numerator: 5,
-        trade_fee_denominator: 1000,
-        owner_trade_fee_numerator: 3,
-        owner_trade_fee_denominator: 1000,
+        trade_fee_numerator: 20,
+        trade_fee_denominator: 10000,
+        owner_trade_fee_numerator: 10,
+        owner_trade_fee_denominator: 10000,
         owner_withdraw_fee_numerator: 3,
         owner_withdraw_fee_denominator: 1000,
     };

--- a/token-swap/program/tests/helpers/mod.rs
+++ b/token-swap/program/tests/helpers/mod.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 
 use {
-    solana_program::{hash::Hash, program_pack::Pack, pubkey::Pubkey, system_instruction},
+    solana_program::{instruction::Instruction, hash::Hash, program_pack::Pack, pubkey::Pubkey, system_instruction},
     solana_program_test::*,
     solana_sdk::{
         signature::{Keypair, Signer},
@@ -29,14 +29,20 @@ pub fn program_test() -> ProgramTest {
     )
 }
 
-pub async fn create_standard_setup(
+pub async fn create_standard_setup<'a>(
     banks_client: &mut BanksClient,
     payer: &Keypair,
     recent_blockhash: &Hash,
+    pool_registry_key: Option<Pubkey>,
+    token_a_mint: &'a Keypair,
+    token_b_mint: &'a Keypair,
     token_a_amount: u64,
     token_b_amount: u64,
-) -> TokenSwapAccounts {
-    let pool_registry_key = create_pool_registry(banks_client, payer, recent_blockhash, payer).await.unwrap();
+) -> TokenSwapAccounts<'a> {
+    let pool_registry_key = pool_registry_key.unwrap_or(
+        create_pool_registry(banks_client, payer, recent_blockhash, payer)
+        .await
+        .unwrap());
 
     let fees = Fees {
         trade_fee_numerator: 1,
@@ -59,6 +65,8 @@ pub async fn create_standard_setup(
         pool_registry_key,
         fees,
         swap_curve,
+        token_a_mint,
+        token_b_mint,
         token_a_amount,
         token_b_amount,
     )
@@ -361,16 +369,16 @@ pub async fn create_pool_registry(
     Ok(pool_registry_key)
 }
 
-pub struct TokenSwapAccounts {
+pub struct TokenSwapAccounts<'a> {
     pub fees: Fees,
     pub swap_curve: SwapCurve,
     pub swap_pubkey: Pubkey,
     pub authority_pubkey: Pubkey,
     pub nonce: u8,
     pub token_a_key: Keypair,
-    pub token_a_mint_key: Keypair,
+    pub token_a_mint_key: &'a Keypair,
     pub token_b_key: Keypair,
-    pub token_b_mint_key: Keypair,
+    pub token_b_mint_key: &'a Keypair,
     pub pool_mint_key: Keypair,
     pub pool_fee_key: Keypair,
     pub pool_token_key: Keypair,
@@ -378,7 +386,7 @@ pub struct TokenSwapAccounts {
     pub pool_nonce: u8,
 }
 
-impl TokenSwapAccounts {
+impl<'a> TokenSwapAccounts<'a> {
     pub async fn new(
         mut banks_client: &mut BanksClient,
         payer: &Keypair,
@@ -386,13 +394,13 @@ impl TokenSwapAccounts {
         pool_registry_pubkey: Pubkey,
         fees: Fees,
         swap_curve: SwapCurve,
+        token_a_mint_key: &'a Keypair,
+        token_b_mint_key: &'a Keypair,
         token_a_amount: u64,
         token_b_amount: u64,
-    ) -> Self {
+    ) -> TokenSwapAccounts<'a> {
         //random keys for these
-        let token_a_mint_key = Keypair::new();
         let token_a_key = Keypair::new();
-        let token_b_mint_key = Keypair::new();
         let token_b_key = Keypair::new();
         let pool_mint_key = Keypair::new();
         let pool_fee_key = Keypair::new();
@@ -485,6 +493,7 @@ impl TokenSwapAccounts {
         )
         .await
         .unwrap();
+
         //create the B mint and pool's token account
         create_mint(
             &mut banks_client,
@@ -560,6 +569,109 @@ impl TokenSwapAccounts {
                 self.pool_nonce,
             )
             .unwrap()],
+            Some(&payer.pubkey()),
+        );
+        transaction.sign(&[payer], *recent_blockhash);
+        banks_client.process_transaction(transaction).await?;
+        Ok(())
+    }
+
+    pub async fn routed_swap(
+        &mut self,
+        banks_client: &mut BanksClient,
+        payer: &Keypair,
+        recent_blockhash: &Hash,
+        other_swap: &TokenSwapAccounts<'a>,
+        token_a: &Pubkey,
+        token_b: Option<&Pubkey>,
+        token_c: Option<&Pubkey>,
+        amt_in: u64,
+        amt_out: u64,
+    ) -> Result<(), TransportError> {
+        let mut ins = Vec::<Instruction>::new();
+        let mut created_token_b = false;
+        //if token_b needs created, create it
+        let token_b = match token_b {
+            Some(t) => *t,
+            _ => {
+                //create ata
+                ins.push(spl_associated_token_account::create_associated_token_account(
+                    &payer.pubkey(), 
+                    &payer.pubkey(), 
+                    &self.token_b_mint_key.pubkey(),
+                ));
+                created_token_b = true;
+                spl_associated_token_account::get_associated_token_address(
+                    &payer.pubkey(), 
+                    &self.token_b_mint_key.pubkey(),
+                )
+            },
+        };
+        //if token_c needs created, create it
+        let token_c = match token_c {
+            Some(t) => *t,
+            _ => {
+                //create ata
+                ins.push(spl_associated_token_account::create_associated_token_account(
+                    &payer.pubkey(), 
+                    &payer.pubkey(), 
+                    &other_swap.token_b_mint_key.pubkey(),
+                ));
+                spl_associated_token_account::get_associated_token_address(
+                    &payer.pubkey(), 
+                    &other_swap.token_b_mint_key.pubkey(),
+                )
+            },
+        };
+
+        //swap ins
+        ins.push(
+            instruction::routed_swap(
+                &id(),
+                &spl_token::id(),
+                &self.swap_pubkey,
+                &self.authority_pubkey,
+                &payer.pubkey(),
+                token_a,
+                &self.token_a_key.pubkey(),
+                &self.token_b_key.pubkey(),
+                &token_b,
+                &self.pool_mint_key.pubkey(),
+                &self.pool_fee_key.pubkey(),
+
+                &other_swap.swap_pubkey,
+                &other_swap.authority_pubkey,
+                &other_swap.token_a_key.pubkey(),
+                &other_swap.token_b_key.pubkey(),
+                &token_c,
+                &other_swap.pool_mint_key.pubkey(),
+                &other_swap.pool_fee_key.pubkey(),
+                instruction::Swap {
+                    amount_in: amt_in,
+                    minimum_amount_out: amt_out,
+                },
+            ).unwrap()
+        );
+
+        //cleanup the intermediary token account if we created it
+        if created_token_b {
+            ins.push(
+                spl_token::instruction::close_account(
+                    &spl_token::id(), 
+                    &token_b, 
+                    &payer.pubkey(), 
+                    &payer.pubkey(), 
+                    &[
+                        &payer.pubkey()
+                    ]
+                ).unwrap()
+            );
+        }
+
+        //now create and execute tx
+        
+        let mut transaction = Transaction::new_with_payer(
+            &ins.into_boxed_slice(),
             Some(&payer.pubkey()),
         );
         transaction.sign(&[payer], *recent_blockhash);

--- a/token-swap/program/tests/helpers/mod.rs
+++ b/token-swap/program/tests/helpers/mod.rs
@@ -45,12 +45,12 @@ pub async fn create_standard_setup<'a>(
         .unwrap());
 
     let fees = Fees {
-        trade_fee_numerator: 1,
-        trade_fee_denominator: 2,
-        owner_trade_fee_numerator: 1,
-        owner_trade_fee_denominator: 10,
-        owner_withdraw_fee_numerator: 1,
-        owner_withdraw_fee_denominator: 5,
+        trade_fee_numerator: 5,
+        trade_fee_denominator: 1000,
+        owner_trade_fee_numerator: 3,
+        owner_trade_fee_denominator: 1000,
+        owner_withdraw_fee_numerator: 3,
+        owner_withdraw_fee_denominator: 1000,
     };
 
     let swap_curve = SwapCurve {
@@ -172,6 +172,13 @@ pub async fn create_account(
     transaction.sign(&[payer, account], *recent_blockhash);
     banks_client.process_transaction(transaction).await?;
     Ok(())
+}
+
+pub async fn get_token_balance(banks_client: &mut BanksClient, token: &Pubkey) -> u64 {
+    let token_account = banks_client.get_account(*token).await.unwrap().unwrap();
+    let account_info: spl_token::state::Account =
+        spl_token::state::Account::unpack_from_slice(token_account.data.as_slice()).unwrap();
+    account_info.amount
 }
 
 pub async fn create_account_with_seed(

--- a/token-swap/program/tests/initialize.rs
+++ b/token-swap/program/tests/initialize.rs
@@ -27,7 +27,9 @@ use {
 async fn fn_test_initialize_fail_wrong_swap_acct() {
     let (mut banks_client, payer, recent_blockhash) = helpers::program_test().start().await;
 
-    let mut swap = helpers::create_standard_setup(&mut banks_client, &payer, &recent_blockhash, 1000, 2000).await;
+    let mint_a = Keypair::new();
+    let mint_b = Keypair::new();
+    let mut swap = helpers::create_standard_setup(&mut banks_client, &payer, &recent_blockhash, None, &mint_a, &mint_b, 1000, 2000).await;
 
     // wrong pda for swap account
     swap.swap_pubkey = Pubkey::new_unique();
@@ -54,7 +56,9 @@ async fn fn_test_initialize_fail_wrong_swap_acct() {
 async fn fn_test_initialize_fail_wrong_nonce() {
     let (mut banks_client, payer, recent_blockhash) = helpers::program_test().start().await;
 
-    let mut swap = helpers::create_standard_setup(&mut banks_client, &payer, &recent_blockhash, 1000, 2000).await;
+    let mint_a = Keypair::new();
+    let mint_b = Keypair::new();
+    let mut swap = helpers::create_standard_setup(&mut banks_client, &payer, &recent_blockhash, None, &mint_a, &mint_b, 1000, 2000).await;
 
     // wrong nonce for authority_key
     swap.nonce -= 1;
@@ -81,7 +85,9 @@ async fn fn_test_initialize_fail_wrong_nonce() {
 async fn fn_test_initialize_fail_uninit_token_a() {
     let (mut banks_client, payer, recent_blockhash) = helpers::program_test().start().await;
 
-    let mut swap = helpers::create_standard_setup(&mut banks_client, &payer, &recent_blockhash, 1000, 2000).await;
+    let mint_a = Keypair::new();
+    let mint_b = Keypair::new();
+    let mut swap = helpers::create_standard_setup(&mut banks_client, &payer, &recent_blockhash, None, &mint_a, &mint_b, 1000, 2000).await;
 
     // uninitialized token a account
     let token_a_key = Keypair::new();
@@ -121,7 +127,9 @@ async fn fn_test_initialize_fail_uninit_token_a() {
 async fn fn_test_initialize_fail_uninit_token_b() {
     let (mut banks_client, payer, recent_blockhash) = helpers::program_test().start().await;
 
-    let mut swap = helpers::create_standard_setup(&mut banks_client, &payer, &recent_blockhash, 1000, 2000).await;
+    let mint_a = Keypair::new();
+    let mint_b = Keypair::new();
+    let mut swap = helpers::create_standard_setup(&mut banks_client, &payer, &recent_blockhash, None, &mint_a, &mint_b, 1000, 2000).await;
 
     // uninitialized token b account
     let token_b_key = Keypair::new();
@@ -161,7 +169,9 @@ async fn fn_test_initialize_fail_uninit_token_b() {
 async fn fn_test_initialize_fail_uninit_pool_mint() {
     let (mut banks_client, payer, recent_blockhash) = helpers::program_test().start().await;
 
-    let mut swap = helpers::create_standard_setup(&mut banks_client, &payer, &recent_blockhash, 1000, 2000).await;
+    let mint_a = Keypair::new();
+    let mint_b = Keypair::new();
+    let mut swap = helpers::create_standard_setup(&mut banks_client, &payer, &recent_blockhash, None, &mint_a, &mint_b, 1000, 2000).await;
 
     // uninitialized pool mint
     let pool_mint_key = Keypair::new();
@@ -201,7 +211,9 @@ async fn fn_test_initialize_fail_uninit_pool_mint() {
 async fn fn_test_initialize_fail_token_a_wrong_owner() {
     let (mut banks_client, payer, recent_blockhash) = helpers::program_test().start().await;
 
-    let mut swap = helpers::create_standard_setup(&mut banks_client, &payer, &recent_blockhash, 1000, 2000).await;
+    let mint_a = Keypair::new();
+    let mint_b = Keypair::new();
+    let mut swap = helpers::create_standard_setup(&mut banks_client, &payer, &recent_blockhash, None, &mint_a, &mint_b, 1000, 2000).await;
 
     // token A account owner is not swap authority
     let new_account = Keypair::new();
@@ -252,7 +264,9 @@ async fn fn_test_initialize_fail_token_a_wrong_owner() {
 async fn fn_test_initialize_fail_token_b_wrong_owner() {
     let (mut banks_client, payer, recent_blockhash) = helpers::program_test().start().await;
 
-    let mut swap = helpers::create_standard_setup(&mut banks_client, &payer, &recent_blockhash, 1000, 2000).await;
+    let mint_a = Keypair::new();
+    let mint_b = Keypair::new();
+    let mut swap = helpers::create_standard_setup(&mut banks_client, &payer, &recent_blockhash, None, &mint_a, &mint_b, 1000, 2000).await;
 
     // token B account owner is not swap authority
     let new_account = Keypair::new();
@@ -303,7 +317,9 @@ async fn fn_test_initialize_fail_token_b_wrong_owner() {
 async fn fn_test_initialize_fail_pool_token_owner_is_swap_authority() {
     let (mut banks_client, payer, recent_blockhash) = helpers::program_test().start().await;
 
-    let mut swap = helpers::create_standard_setup(&mut banks_client, &payer, &recent_blockhash, 1000, 2000).await;
+    let mint_a = Keypair::new();
+    let mint_b = Keypair::new();
+    let mut swap = helpers::create_standard_setup(&mut banks_client, &payer, &recent_blockhash, None, &mint_a, &mint_b, 1000, 2000).await;
 
     // pool token account owner is swap authority
     //change the pool token account owner
@@ -340,7 +356,9 @@ async fn fn_test_initialize_fail_pool_token_owner_is_swap_authority() {
 async fn fn_test_initialize_fail_pool_mint_auth_is_not_swap_authority() {
     let (mut banks_client, payer, recent_blockhash) = helpers::program_test().start().await;
 
-    let mut swap = helpers::create_standard_setup(&mut banks_client, &payer, &recent_blockhash, 1000, 2000).await;
+    let mint_a = Keypair::new();
+    let mint_b = Keypair::new();
+    let mut swap = helpers::create_standard_setup(&mut banks_client, &payer, &recent_blockhash, None, &mint_a, &mint_b, 1000, 2000).await;
 
     // pool mint authority is not swap authority
 
@@ -383,7 +401,9 @@ async fn fn_test_initialize_fail_pool_mint_auth_is_not_swap_authority() {
 async fn fn_test_initialize_fail_pool_mint_auth_has_freeze_authority() {
     let (mut banks_client, payer, recent_blockhash) = helpers::program_test().start().await;
 
-    let mut swap = helpers::create_standard_setup(&mut banks_client, &payer, &recent_blockhash, 1000, 2000).await;
+    let mint_a = Keypair::new();
+    let mint_b = Keypair::new();
+    let mut swap = helpers::create_standard_setup(&mut banks_client, &payer, &recent_blockhash, None, &mint_a, &mint_b, 1000, 2000).await;
 
     // pool mint token has freeze authority
 
@@ -429,7 +449,9 @@ async fn fn_test_initialize_fail_pool_mint_auth_has_freeze_authority() {
 async fn fn_test_initialize_pass() {
     let (mut banks_client, payer, recent_blockhash) = helpers::program_test().start().await;
 
-    let mut swap = helpers::create_standard_setup(&mut banks_client, &payer, &recent_blockhash, 1000, 2000).await;
+    let mint_a = Keypair::new();
+    let mint_b = Keypair::new();
+    let mut swap = helpers::create_standard_setup(&mut banks_client, &payer, &recent_blockhash, None, &mint_a, &mint_b, 1000, 2000).await;
 
     // create valid swap
     swap.initialize_swap(&mut banks_client, &payer, &recent_blockhash)
@@ -493,7 +515,9 @@ async fn fn_test_initialize_pass() {
 async fn fn_test_initialize_twice() {
     let (mut banks_client, payer, recent_blockhash) = helpers::program_test().start().await;
 
-    let mut swap = helpers::create_standard_setup(&mut banks_client, &payer, &recent_blockhash, 1000, 2000).await;
+    let mint_a = Keypair::new();
+    let mint_b = Keypair::new();
+    let mut swap = helpers::create_standard_setup(&mut banks_client, &payer, &recent_blockhash, None, &mint_a, &mint_b, 1000, 2000).await;
 
     // create valid swap
     swap.initialize_swap(&mut banks_client, &payer, &recent_blockhash)
@@ -550,13 +574,17 @@ async fn fn_test_initialize_invalid_flat_swap() {
     let token_a_amount = 1000;
     let token_b_amount = 2000;
 
-    let mut swap = helpers::TokenSwapAccounts::new(
+    let mint_a = Keypair::new();
+    let mint_b = Keypair::new();
+    let mut swap: helpers::TokenSwapAccounts = helpers::TokenSwapAccounts::new(
         &mut banks_client,
         &payer,
         &recent_blockhash,
         pool_registry_key,
         fees,
         swap_curve,
+        &mint_a,
+        &mint_b,
         token_a_amount,
         token_b_amount,
     )
@@ -604,13 +632,17 @@ async fn fn_test_initialize_valid_flat_swap() {
     let token_a_amount = 1000;
     let token_b_amount = 2000;
 
-    let mut swap = helpers::TokenSwapAccounts::new(
+    let mint_a = Keypair::new();
+    let mint_b = Keypair::new();
+    let mut swap: helpers::TokenSwapAccounts = helpers::TokenSwapAccounts::new(
         &mut banks_client,
         &payer,
         &recent_blockhash,
         pool_registry_key,
         fees,
         swap_curve,
+        &mint_a,
+        &mint_b,
         token_a_amount,
         token_b_amount,
     )
@@ -644,13 +676,17 @@ async fn fn_test_initialize_invalid_offset_swap() {
     let token_a_amount = 1000;
     let token_b_amount = 2000;
 
-    let mut swap = helpers::TokenSwapAccounts::new(
+    let mint_a = Keypair::new();
+    let mint_b = Keypair::new();
+    let mut swap: helpers::TokenSwapAccounts = helpers::TokenSwapAccounts::new(
         &mut banks_client,
         &payer,
         &recent_blockhash,
         pool_registry_key,
         fees,
         swap_curve,
+        &mint_a,
+        &mint_b,
         token_a_amount,
         token_b_amount,
     )
@@ -698,13 +734,17 @@ async fn fn_test_initialize_valid_offset_swap() {
     let token_a_amount = 1000;
     let token_b_amount = 2000;
 
-    let mut swap = helpers::TokenSwapAccounts::new(
+    let mint_a = Keypair::new();
+    let mint_b = Keypair::new();
+    let mut swap: helpers::TokenSwapAccounts = helpers::TokenSwapAccounts::new(
         &mut banks_client,
         &payer,
         &recent_blockhash,
         pool_registry_key,
         fees,
         swap_curve,
+        &mint_a,
+        &mint_b,
         token_a_amount,
         token_b_amount,
     )

--- a/token-swap/program/tests/swap_router.rs
+++ b/token-swap/program/tests/swap_router.rs
@@ -23,11 +23,11 @@ const USER_TOKEN_A_BAL: u64 = 200_000;
 const USER_WILL_SWAP: u64 = 100_000;
 const USER_WILL_EXPECT: u64 = 114_286;
 //const USER_WILL_RECEIVE: u64 = 112_463;
-//if router discount used fees
-const USER_WILL_RECEIVE: u64 = 112_691;
+//if 1/2 router discount used fees
+const USER_WILL_RECEIVE: u64 = 112_806;
 
 #[tokio::test]
-async fn fn_dual_swap_create_b_c() {
+async fn fn_swap_router_create_b_c() {
     let user = Keypair::new();
 
     let mut pt = helpers::program_test();
@@ -186,7 +186,7 @@ async fn fn_dual_swap_create_b_c() {
 }
 
 #[tokio::test]
-async fn fn_dual_swap_create_b() {
+async fn fn_swap_router_create_b() {
     let user = Keypair::new();
 
     let mut pt = helpers::program_test();
@@ -326,7 +326,7 @@ async fn fn_dual_swap_create_b() {
 }
 
 #[tokio::test]
-async fn fn_dual_swap_reuse_all() {
+async fn fn_swap_router_reuse_all() {
     let user = Keypair::new();
 
     let mut pt = helpers::program_test();

--- a/token-swap/program/tests/swap_router.rs
+++ b/token-swap/program/tests/swap_router.rs
@@ -20,11 +20,11 @@ const POOL_TOKEN_B_AMOUNT: u64 = 600_000_000_000_000;
 const POOL_TOKEN_B2_AMOUNT: u64 = 300_000_000_000_000;
 const POOL_TOKEN_C_AMOUNT: u64 = 400_000_000_000_000;
 const USER_TOKEN_A_BAL: u64 = 200_000;
-const USER_WILL_SWAP: u64 = 100_000;
+const USER_WILL_SWAP: u64 = 99_999;
 const USER_WILL_EXPECT: u64 = 114_286;
 //const USER_WILL_RECEIVE: u64 = 112_463;
 //if 1/2 router discount used fees
-const USER_WILL_RECEIVE: u64 = 112_806;
+const USER_WILL_RECEIVE: u64 = 113_715; //after 0.5% fee
 
 #[tokio::test]
 async fn fn_swap_router_create_b_c() {

--- a/token-swap/program/tests/swap_router.rs
+++ b/token-swap/program/tests/swap_router.rs
@@ -24,7 +24,7 @@ const USER_WILL_SWAP: u64 = 99_999;
 const USER_WILL_EXPECT: u64 = 114_286;
 //const USER_WILL_RECEIVE: u64 = 112_463;
 //if 1/2 router discount used fees
-const USER_WILL_RECEIVE: u64 = 113_715; //after 0.5% fee
+const USER_WILL_RECEIVE: u64 = 113_694; //after 0.6% fee
 
 #[tokio::test]
 async fn fn_swap_router_create_b_c() {


### PR DESCRIPTION
- Adjusted fee mins to align with .2% and .1% 
- Added an operation on the token-swap program which allows for swapping through a middle pool.
- Hardcoded an owner fee discount on the routed swap of 6/10.  So a routed swap costs 1.12x in fees instead of 2x.  
- Updated the js libs and tests

## Thoughts
The owner fee discount on routing wasn't originally planned - we can remove it if we want.  This is a value add that would have to be publicized in an attempt to show users we offer discounts that others don't.  If we don't market it - we might as well not do it.