### PR TITLE
Dust collection

### DIFF
--- a/token-swap/program/tests/swap_router.rs
+++ b/token-swap/program/tests/swap_router.rs
@@ -186,6 +186,115 @@ async fn fn_swap_router_create_b_c() {
 }
 
 #[tokio::test]
+async fn fn_swap_router_test_dust_collection() {
+    let user = Keypair::new();
+
+    let mut pt = helpers::program_test();
+    //throw our user account directly onto the chain startup
+    pt.add_account(
+        user.pubkey(),
+        Account::new(100_000_000_000, 0, &system_program::id()),
+    );
+    let (mut banks_client, payer, recent_blockhash) = pt.start().await;
+
+    let token_a_mint_key = Keypair::new();
+    let token_b_mint_key = Keypair::new();
+    let token_c_mint_key = Keypair::new();
+
+    //lp1
+    let mut swap1 = helpers::create_standard_setup(
+        &mut banks_client,
+        &payer,
+        &recent_blockhash,
+        None,
+        &token_a_mint_key,
+        &token_b_mint_key,
+        POOL_TOKEN_A_AMOUNT,
+        POOL_TOKEN_B_AMOUNT,
+    )
+    .await;
+    swap1
+        .initialize_swap(&mut banks_client, &payer, &recent_blockhash)
+        .await
+        .unwrap();
+
+    //lp2
+    let mut swap2 = helpers::create_standard_setup(
+        &mut banks_client,
+        &payer,
+        &recent_blockhash,
+        //reuse same registry
+        Some(swap1.pool_registry_pubkey.clone()),
+        //use the same mint as the right side of swap1
+        &token_b_mint_key,
+        &token_c_mint_key,
+        765552903928391,//big prime,
+        506261786074157,//big prime,
+    )
+    .await;
+    swap2
+        .initialize_swap(&mut banks_client, &payer, &recent_blockhash)
+        .await
+        .unwrap();
+
+    //our test swap will be
+    //100,000 A in -> 85,714 B -> 114,286 C out (excluding fees)
+    let amount_user_will_have: u64 = USER_TOKEN_A_BAL;
+    let amount_user_will_swap: u64 = USER_WILL_SWAP;
+    let mut amount_user_expects: u64 = 0;
+
+    //setup our users token account, owned and paid for by user
+    let user_token_a = Keypair::new();
+    helpers::create_token_account(
+        &mut banks_client,
+        &user,
+        &recent_blockhash,
+        &user_token_a,
+        &swap1.token_a_mint_key.pubkey(),
+        &user.pubkey(),
+    )
+    .await
+    .unwrap();
+    //mint tokens to the users account using payer
+    helpers::mint_tokens(
+        &mut banks_client,
+        &payer,
+        &recent_blockhash,
+        &swap1.token_a_mint_key.pubkey(),
+        &user_token_a.pubkey(),
+        &payer,
+        amount_user_will_have,
+    )
+    .await
+    .unwrap();
+
+    {
+    swap1
+        .routed_swap(
+            &mut banks_client,
+            &user,
+            &recent_blockhash,
+            &swap2,
+            &user_token_a.pubkey(),
+            None,
+            None,
+            amount_user_will_swap,
+            amount_user_expects,
+        )
+        .await
+        .unwrap();
+    }
+
+    //verify b account doesnt exist
+    let user_token_b = spl_associated_token_account::get_associated_token_address(
+        &user.pubkey(), 
+        &token_b_mint_key.pubkey(),
+    );
+    let is = banks_client.get_account(user_token_b).await.unwrap();
+    assert_eq!(is, None);
+}
+
+#[tokio::test]
 async fn fn_swap_router_create_b() {
     let user = Keypair::new();
 


### PR DESCRIPTION
In order to clean up dust left behind after swap, on the second half of a routed swap, always set the source swap amount to the amount requested.