### PR TITLE
Cleaner swap

### DIFF
--- a/token-swap/do.sh
+++ b/token-swap/do.sh
@@ -3,7 +3,7 @@
 set -ex
 cd "$(dirname "$0")"
 
-solana_version="1.7.8"
+solana_version="1.7.11"
 #export PATH="$HOME"/.local/share/solana/install/active_release/bin:"$PATH"
 
 usage() {

--- a/token-swap/js/cli/main.ts
+++ b/token-swap/js/cli/main.ts
@@ -10,6 +10,8 @@ import {
   createSecondTokenSwapForRouting,
   routedSwap,
   createAccountsAndRoutedSwapAtomic,
+  createThirdTokenSwapForNative,
+  swapNative,
 } from './token-swap-test';
 
 async function main() {
@@ -41,6 +43,12 @@ async function main() {
   await routedSwap();
   console.log('Success\n');
   await createAccountsAndRoutedSwapAtomic();
+  
+  console.log('Run test: createThirdTokenSwap');
+  await createThirdTokenSwapForNative();
+  console.log('Run test: swapNative');
+  await swapNative();
+
   console.log('Success\n');
 }
 

--- a/token-swap/js/cli/token-swap-test.ts
+++ b/token-swap/js/cli/token-swap-test.ts
@@ -687,6 +687,7 @@ export async function createAccountAndSwapAtomic(): Promise<void> {
       newAccount.publicKey,
       tokenSwap.poolToken,
       tokenSwap.feeAccount,
+      owner.publicKey,
       tokenSwap.swapProgramId,
       tokenSwap.tokenProgramId,
       SWAP_AMOUNT_IN,
@@ -734,6 +735,7 @@ export async function swap(): Promise<void> {
     tokenAccountB,
     userAccountB,
     userTransferAuthority,
+    owner.publicKey,
     SWAP_AMOUNT_IN,
     SWAP_AMOUNT_OUT,
   );
@@ -805,8 +807,10 @@ export async function routedSwap(): Promise<void> {
   info = await mintA.getAccountInfo(userAccountA);
   assert(info.amount.toNumber() == 0);
 
-  info = await mintB.getAccountInfo(userAccountB);
-  assert(info.amount.toNumber() == 0);
+  try {
+    await mintB.getAccountInfo(userAccountB);
+    assert(false, "user intermediary account should not exist");
+  } catch { }
 
   info = await mintC.getAccountInfo(userAccountC);
   console.log("ROUTED_SWAP_AMOUNT_OUT2",info.amount.toNumber());

--- a/token-swap/js/cli/token-swap-test.ts
+++ b/token-swap/js/cli/token-swap-test.ts
@@ -781,6 +781,8 @@ export async function routedSwap(): Promise<void> {
   console.log('Creating swap token c account');
   let userAccountC = await mintC.createAccount(owner.publicKey);
 
+  console.log('userTransferAuthority', userTransferAuthority.publicKey.toString());
+  console.log('owner.publicKey', owner.publicKey.toString());
   console.log('Swapping');
   await tokenSwap.routedSwap(
     userAccountA,
@@ -791,6 +793,7 @@ export async function routedSwap(): Promise<void> {
     tokenAccountC,
     userAccountC,
     userTransferAuthority,
+    owner.publicKey,
     tokenSwap2,
     SWAP_AMOUNT_IN, 
     ROUTED_SWAP_AMOUNT_OUT2,
@@ -925,21 +928,11 @@ export async function createAccountsAndRoutedSwapAtomic(): Promise<void> {
       newAccountC,
       tokenSwap2.poolToken,
       tokenSwap2.feeAccount,
+      owner.publicKey,
       tokenSwap.swapProgramId,
       tokenSwap.tokenProgramId,
       SWAP_AMOUNT_IN,
       0,  //apps should set this for sure, but in this test can't be ROUTED_SWAP_AMOUNT_OUT anymore because we already swapped some
-    ),
-  );
-
-  //close the middle(B) account we created for the routing
-  transaction.add(
-    Token.createCloseAccountInstruction(
-      mintB.programId,
-      newAccountB.publicKey,
-      owner.publicKey,
-      userTransferAuthority.publicKey,
-      [userTransferAuthority],
     ),
   );
 

--- a/token-swap/js/package.json
+++ b/token-swap/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stepfinance/step-swap",
-  "version": "0.1.7",
+  "version": "0.1.9",
   "description": "Step Token Swap JavaScript API",
   "license": "MIT",
   "author": "Step <dev@step.finance>",

--- a/token-swap/js/src/index.ts
+++ b/token-swap/js/src/index.ts
@@ -664,7 +664,7 @@ export class TokenSwap {
    * @param poolSourceB Pool's source token B account
    * @param poolDestinationC Pool's destination token C account
    * @param userDestinationC User's destination token C account
-   * @param userTransferAuthority Account delegated to transfer user's tokens, must own the intermediary account
+   * @param userTransferAuthority Account delegated to transfer user's tokens, must own the intermediary account and wrapped SOL output accounts
    * @param refundTo The account to send intermediate account close funds to, and to unwrap SOL to
    * @param tokenSwapForBtoC The second TokenSwap object representing the B to C swap
    * @param amountIn Amount to transfer from source account

--- a/token-swap/js/src/index.ts
+++ b/token-swap/js/src/index.ts
@@ -673,6 +673,7 @@ export class TokenSwap {
     poolDestinationC: PublicKey,
     userDestinationC: PublicKey,
     userTransferAuthority: Keypair,
+    refundTo: PublicKey,
     tokenSwapForBtoC: TokenSwap,
     amountIn: number | Numberu64,
     minimumAmountOut: number | Numberu64,
@@ -698,6 +699,7 @@ export class TokenSwap {
           userDestinationC,
           tokenSwapForBtoC.poolToken,
           tokenSwapForBtoC.feeAccount,
+          refundTo,
           this.swapProgramId,
           this.tokenProgramId,
           amountIn,
@@ -726,6 +728,7 @@ export class TokenSwap {
     userDestination2: PublicKey,
     poolMint2: PublicKey,
     feeAccount2: PublicKey,
+    refundTo: PublicKey,
     swapProgramId: PublicKey,
     tokenProgramId: PublicKey,
     amountIn: number | Numberu64,
@@ -765,6 +768,7 @@ export class TokenSwap {
       {pubkey: userDestination2, isSigner: false, isWritable: true},
       {pubkey: poolMint2, isSigner: false, isWritable: true},
       {pubkey: feeAccount2, isSigner: false, isWritable: true},
+      {pubkey: refundTo, isSigner: false, isWritable: true},
     ];
     return new TransactionInstruction({
       keys,

--- a/token-swap/js/src/index.ts
+++ b/token-swap/js/src/index.ts
@@ -562,6 +562,7 @@ export class TokenSwap {
    * @param poolDestination Pool's destination token account
    * @param userDestination User's destination token account
    * @param userTransferAuthority Account delegated to transfer user's tokens
+   * @param refundTo The account to send intermediate account close funds to, and to unwrap SOL to
    * @param amountIn Amount to transfer from source account
    * @param minimumAmountOut Minimum amount of tokens the user will receive
    */
@@ -571,6 +572,7 @@ export class TokenSwap {
     poolDestination: PublicKey,
     userDestination: PublicKey,
     userTransferAuthority: Keypair,
+    refundTo: PublicKey,
     amountIn: number | Numberu64,
     minimumAmountOut: number | Numberu64,
   ): Promise<TransactionSignature> {
@@ -588,6 +590,7 @@ export class TokenSwap {
           userDestination,
           this.poolToken,
           this.feeAccount,
+          refundTo,
           this.swapProgramId,
           this.tokenProgramId,
           amountIn,
@@ -609,6 +612,7 @@ export class TokenSwap {
     userDestination: PublicKey,
     poolMint: PublicKey,
     feeAccount: PublicKey,
+    refundTo: PublicKey,
     swapProgramId: PublicKey,
     tokenProgramId: PublicKey,
     amountIn: number | Numberu64,
@@ -640,6 +644,7 @@ export class TokenSwap {
       {pubkey: userDestination, isSigner: false, isWritable: true},
       {pubkey: poolMint, isSigner: false, isWritable: true},
       {pubkey: feeAccount, isSigner: false, isWritable: true},
+      {pubkey: refundTo, isSigner: false, isWritable: true},
       {pubkey: tokenProgramId, isSigner: false, isWritable: false},
     ];
     return new TransactionInstruction({
@@ -659,7 +664,8 @@ export class TokenSwap {
    * @param poolSourceB Pool's source token B account
    * @param poolDestinationC Pool's destination token C account
    * @param userDestinationC User's destination token C account
-   * @param userTransferAuthority Account delegated to transfer user's tokens
+   * @param userTransferAuthority Account delegated to transfer user's tokens, must own the intermediary account
+   * @param refundTo The account to send intermediate account close funds to, and to unwrap SOL to
    * @param tokenSwapForBtoC The second TokenSwap object representing the B to C swap
    * @param amountIn Amount to transfer from source account
    * @param minimumAmountOut Minimum amount of tokens the user will receive

--- a/token-swap/program/src/error.rs
+++ b/token-swap/program/src/error.rs
@@ -104,7 +104,10 @@ pub enum SwapError {
     UnsupportedCurveOperation,
     /// Non-native token output to transfer authority owned account
     #[error("Non-native token output to transfer authority owned account")]
-    TransferAuthorityOwnsNonNativeOutput
+    NonRefunderTransferAuthorityOwnsNonNativeOutput,
+    /// A refunder is required when a non-owner transfer authority owns native output
+    #[error("A refunder is required when a non-owner transfer authority owns native output")]
+    TransferAuthorityOwnsNativeOutputRefunderEmpty,
 }
 impl From<SwapError> for ProgramError {
     fn from(e: SwapError) -> Self {

--- a/token-swap/program/src/error.rs
+++ b/token-swap/program/src/error.rs
@@ -102,6 +102,9 @@ pub enum SwapError {
     /// The operation cannot be performed on the given curve
     #[error("The operation cannot be performed on the given curve")]
     UnsupportedCurveOperation,
+    /// Non-native token output to transfer authority owned account
+    #[error("Non-native token output to transfer authority owned account")]
+    TransferAuthorityOwnsNonNativeOutput
 }
 impl From<SwapError> for ProgramError {
     fn from(e: SwapError) -> Self {

--- a/token-swap/program/src/instruction.rs
+++ b/token-swap/program/src/instruction.rs
@@ -126,8 +126,8 @@ pub enum SwapInstruction {
     ///   5. `[writable]` token_(A|B) Base Account to swap FROM.  Must be the DESTINATION token.
     ///   6. `[writable]` token_(A|B) DESTINATION Account assigned to USER as the owner.
     ///   7. `[writable]` Pool token mint, to generate trading fees
-    ///   8. '[]` Token program id
-    ///   9 `[optional, writable]` Host fee account to receive additional trading fees
+    ///   8. `[writable]` refund account to unwrap WSOL to
+    ///   9. '[]` Token program id
     Swap(Swap),
 
     ///   Deposit both types of tokens into the pool.  The output is a "pool"
@@ -219,6 +219,7 @@ pub enum SwapInstruction {
     ///   12. `[writable]` token_(A|B) Base Account to swap FROM.  Must be the DESTINATION token.
     ///   13. `[writable]` token_(A|B) DESTINATION Account assigned to USER as the owner.
     ///   14. `[writable]` Pool token mint, to generate trading fees
+    ///   15. `[writable]` refund account to unwrap WSOL to
     RoutedSwap(Swap),
 }
 
@@ -609,6 +610,8 @@ pub fn swap(
     pool_mint_pubkey: &Pubkey,
     pool_fee_pubkey: &Pubkey,
     host_fee_pubkey: Option<&Pubkey>,
+    //for unwrapping sol
+    refund_pubkey: &Pubkey,
     instruction: Swap,
 ) -> Result<Instruction, ProgramError> {
     let data = SwapInstruction::Swap(instruction).pack();
@@ -623,6 +626,7 @@ pub fn swap(
         AccountMeta::new(*destination_pubkey, false),
         AccountMeta::new(*pool_mint_pubkey, false),
         AccountMeta::new(*pool_fee_pubkey, false),
+        AccountMeta::new(*refund_pubkey, false),
         AccountMeta::new_readonly(*token_program_id, false),
     ];
     if let Some(host_fee_pubkey) = host_fee_pubkey {

--- a/token-swap/program/src/instruction.rs
+++ b/token-swap/program/src/instruction.rs
@@ -658,6 +658,8 @@ pub fn routed_swap(
     destination_pubkey2: &Pubkey,
     pool_mint_pubkey2: &Pubkey,
     pool_fee_pubkey2: &Pubkey,
+    //for unwrap and cleanup
+    refund_pubkey: &Pubkey,
 
     instruction: Swap,
 ) -> Result<Instruction, ProgramError> {
@@ -682,6 +684,7 @@ pub fn routed_swap(
         AccountMeta::new(*destination_pubkey2, false),
         AccountMeta::new(*pool_mint_pubkey2, false),
         AccountMeta::new(*pool_fee_pubkey2, false),
+        AccountMeta::new(*refund_pubkey, false),
     ];
 
     Ok(Instruction {

--- a/token-swap/program/src/processor.rs
+++ b/token-swap/program/src/processor.rs
@@ -707,19 +707,20 @@ impl Processor {
         if close_wsol {
             if let Some(refund) = refund_account_info {
                 let token_c = Self::unpack_token_account(destination_info, token_program_info.key)?;
-                if token_c.owner == *refund.key 
+                if token_c.owner == *user_transfer_authority_info.key 
                         && token_c.is_native.is_some() {
                     invoke(
                         &spl_token::instruction::close_account(
                             token_program_info.key,
                             destination_info.key,
                             refund.key,
-                            refund.key,
+                            user_transfer_authority_info.key,
                             &[],
                         )?,
                         &[
                             destination_info.clone(),
                             refund.clone(),
+                            user_transfer_authority_info.clone(),
                         ],
                     )?;
                 }

--- a/token-swap/program/src/processor.rs
+++ b/token-swap/program/src/processor.rs
@@ -703,28 +703,36 @@ impl Processor {
             to_u64(result.destination_amount_swapped)?,
         )?;
 
-        //if the destination token is WSOL, we close it
-        if close_wsol {
-            if let Some(refund) = refund_account_info {
-                let token_c = Self::unpack_token_account(destination_info, token_program_info.key)?;
-                if token_c.owner == *user_transfer_authority_info.key 
-                        && token_c.is_native.is_some() {
-                    invoke(
-                        &spl_token::instruction::close_account(
-                            token_program_info.key,
-                            destination_info.key,
-                            refund.key,
-                            user_transfer_authority_info.key,
-                            &[],
-                        )?,
-                        &[
-                            destination_info.clone(),
-                            refund.clone(),
-                            user_transfer_authority_info.clone(),
-                        ],
-                    )?;
-                }
+        //if the destination token is WSOL, we close it if we can
+        let token_c = Self::unpack_token_account(destination_info, token_program_info.key)?;
+        if token_c.owner == *user_transfer_authority_info.key {
+            //if the transfer authority owns this token, we do not want to exit this operation
+            //without handling the closing of the token
+            if refund_account_info.is_none() || token_c.is_native.is_none() || !close_wsol
+            {
+                //currently there is no valid reason for the transfer authority to own
+                //a non-native output token; this would likely be a bug to the inputs
+                //which if left unchecked would result in a stranded token
+                return Err(SwapError::TransferAuthorityOwnsNonNativeOutput.into());
             }
+            let refund = refund_account_info.unwrap();
+            invoke(
+                &spl_token::instruction::close_account(
+                    token_program_info.key,
+                    destination_info.key,
+                    refund.key,
+                    user_transfer_authority_info.key,
+                    &[],
+                )?,
+                &[
+                    destination_info.clone(),
+                    refund.clone(),
+                    user_transfer_authority_info.clone(),
+                ],
+            )?;
+        //if we should have closed but authority was set wrong, just leave a message?
+        } else if close_wsol && token_c.is_native.is_none() {
+            msg!("couldn't close native token; user transfer authority must own");
         }
 
         Ok(result)

--- a/token-swap/program/src/processor.rs
+++ b/token-swap/program/src/processor.rs
@@ -1434,6 +1434,9 @@ impl PrintProgramError for SwapError {
             SwapError::UnsupportedCurveOperation => {
                 msg!("Error: The operation cannot be performed on the given curve")
             }
+            SwapError::TransferAuthorityOwnsNonNativeOutput => {
+                msg!("Error: Non-native token output to transfer authority owned account")
+            }
         }
     }
 }

--- a/token-swap/program/tests/helpers/mod.rs
+++ b/token-swap/program/tests/helpers/mod.rs
@@ -596,7 +596,6 @@ impl<'a> TokenSwapAccounts<'a> {
         amt_out: u64,
     ) -> Result<(), TransportError> {
         let mut ins = Vec::<Instruction>::new();
-        let mut created_token_b = false;
         //if token_b needs created, create it
         let token_b = match token_b {
             Some(t) => *t,
@@ -607,7 +606,6 @@ impl<'a> TokenSwapAccounts<'a> {
                     &payer.pubkey(), 
                     &self.token_b_mint_key.pubkey(),
                 ));
-                created_token_b = true;
                 spl_associated_token_account::get_associated_token_address(
                     &payer.pubkey(), 
                     &self.token_b_mint_key.pubkey(),
@@ -653,27 +651,15 @@ impl<'a> TokenSwapAccounts<'a> {
                 &token_c,
                 &other_swap.pool_mint_key.pubkey(),
                 &other_swap.pool_fee_key.pubkey(),
+
+                &payer.pubkey(),
+
                 instruction::Swap {
                     amount_in: amt_in,
                     minimum_amount_out: amt_out,
                 },
             ).unwrap()
         );
-
-        //cleanup the intermediary token account if we created it
-        if created_token_b {
-            ins.push(
-                spl_token::instruction::close_account(
-                    &spl_token::id(), 
-                    &token_b, 
-                    &payer.pubkey(), 
-                    &payer.pubkey(), 
-                    &[
-                        &payer.pubkey()
-                    ]
-                ).unwrap()
-            );
-        }
 
         //now create and execute tx
         

--- a/token-swap/program/tests/swap_router.rs
+++ b/token-swap/program/tests/swap_router.rs
@@ -186,6 +186,115 @@ async fn fn_swap_router_create_b_c() {
 }
 
 #[tokio::test]
+async fn fn_swap_router_test_dust_collection() {
+    let user = Keypair::new();
+
+    let mut pt = helpers::program_test();
+    //throw our user account directly onto the chain startup
+    pt.add_account(
+        user.pubkey(),
+        Account::new(100_000_000_000, 0, &system_program::id()),
+    );
+    let (mut banks_client, payer, recent_blockhash) = pt.start().await;
+
+    let token_a_mint_key = Keypair::new();
+    let token_b_mint_key = Keypair::new();
+    let token_c_mint_key = Keypair::new();
+
+    //lp1
+    let mut swap1 = helpers::create_standard_setup(
+        &mut banks_client,
+        &payer,
+        &recent_blockhash,
+        None,
+        &token_a_mint_key,
+        &token_b_mint_key,
+        POOL_TOKEN_A_AMOUNT,
+        POOL_TOKEN_B_AMOUNT,
+    )
+    .await;
+    swap1
+        .initialize_swap(&mut banks_client, &payer, &recent_blockhash)
+        .await
+        .unwrap();
+
+    //lp2
+    let mut swap2 = helpers::create_standard_setup(
+        &mut banks_client,
+        &payer,
+        &recent_blockhash,
+        //reuse same registry
+        Some(swap1.pool_registry_pubkey.clone()),
+        //use the same mint as the right side of swap1
+        &token_b_mint_key,
+        &token_c_mint_key,
+        765552903928391,//big prime,
+        506261786074157,//big prime,
+    )
+    .await;
+    swap2
+        .initialize_swap(&mut banks_client, &payer, &recent_blockhash)
+        .await
+        .unwrap();
+
+    //our test swap will be
+    //100,000 A in -> 85,714 B -> 114,286 C out (excluding fees)
+    let amount_user_will_have: u64 = USER_TOKEN_A_BAL;
+    let amount_user_will_swap: u64 = USER_WILL_SWAP;
+    let mut amount_user_expects: u64 = 0;
+
+    //setup our users token account, owned and paid for by user
+    let user_token_a = Keypair::new();
+    helpers::create_token_account(
+        &mut banks_client,
+        &user,
+        &recent_blockhash,
+        &user_token_a,
+        &swap1.token_a_mint_key.pubkey(),
+        &user.pubkey(),
+    )
+    .await
+    .unwrap();
+    //mint tokens to the users account using payer
+    helpers::mint_tokens(
+        &mut banks_client,
+        &payer,
+        &recent_blockhash,
+        &swap1.token_a_mint_key.pubkey(),
+        &user_token_a.pubkey(),
+        &payer,
+        amount_user_will_have,
+    )
+    .await
+    .unwrap();
+
+    {
+    swap1
+        .routed_swap(
+            &mut banks_client,
+            &user,
+            &recent_blockhash,
+            &swap2,
+            &user_token_a.pubkey(),
+            None,
+            None,
+            amount_user_will_swap,
+            amount_user_expects,
+        )
+        .await
+        .unwrap();
+    }
+
+    //verify b account doesnt exist
+    let user_token_b = spl_associated_token_account::get_associated_token_address(
+        &user.pubkey(), 
+        &token_b_mint_key.pubkey(),
+    );
+    let is = banks_client.get_account(user_token_b).await.unwrap();
+    assert_eq!(is, None);
+}
+
+#[tokio::test]
 async fn fn_swap_router_create_b() {
     let user = Keypair::new();
 

--- a/token-swap/program/tests/swap_router.rs
+++ b/token-swap/program/tests/swap_router.rs
@@ -241,7 +241,6 @@ async fn fn_swap_router_test_dust_collection() {
     //100,000 A in -> 85,714 B -> 114,286 C out (excluding fees)
     let amount_user_will_have: u64 = USER_TOKEN_A_BAL;
     let amount_user_will_swap: u64 = USER_WILL_SWAP;
-    let mut amount_user_expects: u64 = 0;
 
     //setup our users token account, owned and paid for by user
     let user_token_a = Keypair::new();
@@ -279,7 +278,7 @@ async fn fn_swap_router_test_dust_collection() {
             None,
             None,
             amount_user_will_swap,
-            amount_user_expects,
+            0,
         )
         .await
         .unwrap();


### PR DESCRIPTION
- Token swap requires refund_acct
- WSOL is automatically unwrapped and refunded to the refund_acct
- Routed swap automatically cleans up the intermediary account if empty and owned for user_transfer_authority