### PR TITLE
add deregister functionality for a pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1931,9 +1931,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d0a3d5e207573f948a9e5376662aa743a2ea13f7c50a554d7af443a73fbfeba"
+checksum = "5f6f7833f2cbf2360a6cfd58cd41a53aa7a90bd4c202f5b1c7dd2ed73c57b2c3"
 dependencies = [
  "autocfg",
  "num-integer",

--- a/token-swap/program/tests/helpers/mod.rs
+++ b/token-swap/program/tests/helpers/mod.rs
@@ -39,10 +39,14 @@ pub async fn create_standard_setup<'a>(
     token_a_amount: u64,
     token_b_amount: u64,
 ) -> TokenSwapAccounts<'a> {
-    let pool_registry_key = pool_registry_key.unwrap_or(
-        create_pool_registry(banks_client, payer, recent_blockhash, payer)
-        .await
-        .unwrap());
+    let pool_registry_key = match pool_registry_key {
+        Some(a) => a,
+        None => {
+            create_pool_registry(banks_client, payer, recent_blockhash, payer)
+            .await
+            .unwrap()
+        },
+    };
 
     let fees = Fees {
         trade_fee_numerator: 20,


### PR DESCRIPTION
- A pool can be deregistered by its index
- The payer key used to derive the registry must sign the operation
- The pool itself is not touched, its pubkey is simply removed from the registry
- Removal implementation is a "replace with last, reduce size by one", and thus the position of pools in the registry is now neither permanent nor a reflection of its creation time.