### PR TITLE
Fix routed swap fee bug

### DIFF
--- a/token-swap/program/src/processor.rs
+++ b/token-swap/program/src/processor.rs
@@ -674,7 +674,7 @@ impl Processor {
                 swap_token_b_amount,
                 to_u128(pool_mint.supply)?,
                 trade_direction,
-                token_swap.fees(),
+                &fees,
             )
             .ok_or(SwapError::FeeCalculationFailure)?;
 


### PR DESCRIPTION
Our routed swaps have a discount on the fee charged - `0.06%` on each side resulting in `~0.12%` when doing a route instead of `0.10%` each side which would result in a `~0.20%`.  This fee discount was being properly applied to the user swapping, but not when paying the owner fee - owner was still getting the full `0.10%` for each side resulting in less fees than intended going to the LP.

Routed swap intended fees:
|Who|Amount|
|---|---|
|User|-0.52%|
|LP|0.40%|
|Owner|0.12%|

Routed swap actual fees before this fix:
|Who|Amount|
|---|---|
|User|-0.52%|
|LP|0.32%|
|Owner|0.20%|

**This only affected routed swaps, so none of the arb or Jupiter activity.**