### PR TITLE
Add repair closed fee accounts operation

### DIFF
--- a/token-swap/program/Cargo.toml
+++ b/token-swap/program/Cargo.toml
@@ -23,6 +23,7 @@ bytemuck = { version = "1.7.2", features = ["derive", "extern_crate_alloc"] }
 solana-program = "1.7.7"
 spl-math = { version = "0.1", path = "../../libraries/math", features = [ "no-entrypoint" ] }
 spl-token = { version = "3.2", path = "../../token/program", features = [ "no-entrypoint" ] }
+spl-associated-token-account = { version = "1.0.3", features = ["no-entrypoint"] }
 thiserror = "1.0"
 arbitrary = { version = "0.4", features = ["derive"], optional = true }
 roots = { version = "0.0.7", optional = true }

--- a/token-swap/program/src/instruction.rs
+++ b/token-swap/program/src/instruction.rs
@@ -273,7 +273,7 @@ pub enum SwapInstruction {
     /// 0. `[writable]` The token swap account to repair.
     /// 1. `[]` The old fee account this must be closed.
     /// 2. `[]` The new fee account. This must be the ATA for the mint and the owner fee account.
-    RepairClosedFeeAccount,
+    RepairClosedFeeAccount(),
 }
 
 impl SwapInstruction {
@@ -470,7 +470,7 @@ impl SwapInstruction {
                 buf.push(8);
                 buf.extend_from_slice(&pool_index.to_le_bytes());
             }
-            Self::RepairClosedFeeAccount => {
+            Self::RepairClosedFeeAccount() => {
                 buf.push(9);
             }
         }
@@ -822,14 +822,14 @@ pub fn deregister_pool(
 }
 
 
-/// Creates an 'repaid_closed_fee_account' instruction.
-pub fn repaid_closed_fee_account(
+/// Creates an 'repair_closed_fee_account' instruction.
+pub fn repair_closed_fee_account(
     program_id: &Pubkey,
     token_swap: &Pubkey,
     old_fee_account: &Pubkey,
     new_fee_account: &Pubkey,
 ) -> Result<Instruction, ProgramError> {
-    let init_data = SwapInstruction::RepairClosedFeeAccount;
+    let init_data = SwapInstruction::RepairClosedFeeAccount();
     let data = init_data.pack();
 
     let accounts = vec![

--- a/token-swap/program/src/instruction.rs
+++ b/token-swap/program/src/instruction.rs
@@ -265,6 +265,15 @@ pub enum SwapInstruction {
     /// 0. `[signer]` The account of deployer.
     /// 1. `[writable]` The pool registry account.
     DeregisterPool(DeregisterPool),
+
+    ///   Repairs a token swap whose fee account is closed
+    ///
+    /// Accounts expected:
+    ///
+    /// 0. `[writable]` The token swap account to repair.
+    /// 1. `[]` The old fee account this must be closed.
+    /// 2. `[]` The new fee account. This must be the ATA for the mint and the owner fee account.
+    RepairClosedFeeAccount,
 }
 
 impl SwapInstruction {
@@ -353,6 +362,8 @@ impl SwapInstruction {
                 Self::DeregisterPool(DeregisterPool {
                     pool_index,
                 })
+            },
+            9 => Self::RepairClosedFeeAccount {
             },
             _ => return Err(SwapError::InvalidInstruction.into()),
         })
@@ -458,6 +469,9 @@ impl SwapInstruction {
             }) => {
                 buf.push(8);
                 buf.extend_from_slice(&pool_index.to_le_bytes());
+            }
+            Self::RepairClosedFeeAccount => {
+                buf.push(9);
             }
         }
         buf
@@ -798,6 +812,30 @@ pub fn deregister_pool(
     let accounts = vec![
         AccountMeta::new(*payer, true),
         AccountMeta::new(*pool_registry_pubkey, false),
+    ];
+
+    Ok(Instruction {
+        program_id: *program_id,
+        accounts,
+        data,
+    })
+}
+
+
+/// Creates an 'repaid_closed_fee_account' instruction.
+pub fn repaid_closed_fee_account(
+    program_id: &Pubkey,
+    token_swap: &Pubkey,
+    old_fee_account: &Pubkey,
+    new_fee_account: &Pubkey,
+) -> Result<Instruction, ProgramError> {
+    let init_data = SwapInstruction::RepairClosedFeeAccount;
+    let data = init_data.pack();
+
+    let accounts = vec![
+        AccountMeta::new(*token_swap, false),
+        AccountMeta::new(*old_fee_account, false),
+        AccountMeta::new(*new_fee_account, false),
     ];
 
     Ok(Instruction {

--- a/token-swap/program/src/processor.rs
+++ b/token-swap/program/src/processor.rs
@@ -13,7 +13,6 @@ use crate::{
         SwapInstruction, WithdrawAllTokenTypes, WithdrawSingleTokenTypeExactAmountOut, swap_flags,
     },
     state::{SwapState, SwapV1, SwapVersion, PoolRegistry},
-    constraints,
 };
 use num_traits::FromPrimitive;
 use solana_program::{
@@ -32,6 +31,12 @@ use solana_program::{
 };
 use spl_associated_token_account::get_associated_token_address;
 use std::convert::TryInto;
+
+
+/// For unit testing, we need to use a owner key when generating ATAs. 
+/// This matches the one in the unit test
+#[cfg(not(feature = "production"))]
+pub const TEST_OWNER_KEY: &str = "5Cebzty8iwgAUx9jyfZVAT2iMvXBECLwEVgT6T8KYmvS";
 
 /// Program state handler.
 pub struct Processor {}
@@ -1381,18 +1386,29 @@ impl Processor {
         if token_swap_account.owner != program_id {
             return Err(ProgramError::IncorrectProgramId);
         }
-
+        
         //no point making no change
         if old_fee_account.key == new_fee_account.key {
             return Err(SwapError::InvalidInput.into());
         }
 
-        //constraints must exist
-        let swap_constraints = constraints::SWAP_CONSTRAINTS
+        //old fee must NOT be a token account (assumed closed, but could be some other reason?)
+        //this makes sure this can only run in a truly broken scenario
+        Self::unpack_token_account(&old_fee_account, &spl_token::id())
+            .err()
             .ok_or_else(|| SwapError::InvalidInput)?;
 
+        //constraints must exist
+        #[cfg(feature = "production")]
+        let owner_key = constraints::SWAP_CONSTRAINTS
+            .map(|c| c.owner_key.parse::<Pubkey>().unwrap())
+            .ok_or_else(|| ProgramError::InvalidInstructionData)?;
+
+        //unit test has no swap constraints, so no owner key - we use our hard coded key
+        #[cfg(not(feature = "production"))]
+        let owner_key = TEST_OWNER_KEY.parse::<Pubkey>().unwrap();
+
         let new_fee_token_account = Self::unpack_token_account(&new_fee_account, &spl_token::id())?;
-        let owner_key = swap_constraints.owner_key.parse::<Pubkey>().unwrap();
 
         //new fee account must be owned by the owner fee account
         if owner_key != new_fee_token_account.owner {
@@ -1409,21 +1425,18 @@ impl Processor {
             return Err(SwapError::InvalidDelegate.into());
         }
 
-        //old fee must NOT be a token account (assumed closed, but could be some other reason?)
-        //this makes sure this can only run in a truly broken scenario
-        Self::unpack_token_account(&old_fee_account, &spl_token::id())
-            .err()
-            .ok_or_else(|| SwapError::InvalidInput)?;
-
         //token swap must parse. 
         //we avoid using the trait returned from SwapVersion::unpack so we have a mutable SwapV1
-        let data = token_swap_account.data.borrow();
-        let (&version, rest) = data
-            .split_first()
-            .ok_or(ProgramError::InvalidAccountData)?;
-        let mut token_swap = match version {
-            1 => Ok(SwapV1::unpack(rest)?),
-            _ => Err(ProgramError::UninitializedAccount),
+        let mut token_swap: SwapV1 =
+        {
+            let data = token_swap_account.data.borrow();
+            let (&version, rest) = data
+                .split_first()
+                .ok_or(ProgramError::InvalidAccountData)?;
+            match version {
+                1 => Ok(SwapV1::unpack(rest)?),
+                _ => Err(ProgramError::UninitializedAccount),
+            }
         }?;
 
         //old fee account key must match whats on our token swap
@@ -1432,6 +1445,7 @@ impl Processor {
         }
 
         //new fee account must be the ata of owner fee address and the pool mint
+        //if owner_key is None, this is in a unit test - we have to use something
         let ata = get_associated_token_address(&owner_key, token_swap.pool_mint());
         if new_fee_account.key != &ata {
             return Err(SwapError::IncorrectFeeAccount.into());
@@ -1564,7 +1578,7 @@ impl Processor {
                 msg!("Instruction: DeregisterPool");
                 Self::process_deregister_pool(program_id, pool_index, accounts)
             }
-            SwapInstruction::RepairClosedFeeAccount => {
+            SwapInstruction::RepairClosedFeeAccount() => {
                 msg!("Instruction: RepairClosedFeeAccount");
                 Self::process_repair_closed_fee_account(
                     program_id,

--- a/token-swap/program/tests/swap_repair.rs
+++ b/token-swap/program/tests/swap_repair.rs
@@ -1,0 +1,539 @@
+#![cfg(any(test, feature = "test-bpf"))]
+
+mod helpers;
+
+use spl_token_swap::state::SwapVersion;
+use {
+    solana_program_test::tokio,
+    solana_sdk::{
+        pubkey::Pubkey,
+        account::Account,
+        signature::{Keypair, Signer},
+        transaction::TransactionError,
+        instruction::InstructionError,
+        system_program,
+    },
+    spl_token_swap::error::SwapError,
+};
+
+const POOL_TOKEN_A_AMOUNT: u64 = 700_000_000;
+const POOL_TOKEN_B_AMOUNT: u64 = 600_000_000;
+const POOL_TOKEN_B2_AMOUNT: u64 = 300_000_000;
+const POOL_TOKEN_C_AMOUNT: u64 = 400_000_000;
+const USER_TOKEN_A_BAL: u64 = 20_00_000;
+const USER_WILL_SWAP: u64 = 100_000;
+//const USER_WILL_EXPECT: u64 = 114_286;
+//const USER_WILL_RECEIVE: u64 = 113_646; 
+
+/// For unit testing, we need to use a owner key when generating ATAs
+pub const TEST_OWNER_KEY: &str = "5Cebzty8iwgAUx9jyfZVAT2iMvXBECLwEVgT6T8KYmvS";
+
+#[tokio::test]
+async fn fn_swap_repair() {
+    let user = Keypair::new();
+
+    let mut pt = helpers::program_test();
+    //throw our user account directly onto the chain startup
+    pt.add_account(
+        user.pubkey(),
+        Account::new(100_000_000_000, 0, &system_program::id()),
+    );
+    let (mut banks_client, payer, recent_blockhash) = pt.start().await;
+
+    let token_a_mint_key = Keypair::new();
+    let token_b_mint_key = Keypair::new();
+    let token_c_mint_key = Keypair::new();
+
+    //grab the atas for later use
+    let user_token_c = spl_associated_token_account::get_associated_token_address(
+        &user.pubkey(), 
+        &token_c_mint_key.pubkey(),
+    );
+
+    //lp1
+    let mut swap1 = helpers::create_standard_setup(
+        &mut banks_client,
+        &payer,
+        &recent_blockhash,
+        None,
+        &token_a_mint_key,
+        &token_b_mint_key,
+        POOL_TOKEN_A_AMOUNT,
+        POOL_TOKEN_B_AMOUNT,
+    )
+    .await;
+
+    swap1
+        .initialize_swap(&mut banks_client, &payer, &recent_blockhash)
+        .await
+        .unwrap();
+
+    //lp2
+    let mut swap2 = helpers::create_standard_setup(
+        &mut banks_client,
+        &payer,
+        &recent_blockhash,
+        //reuse same registry
+        Some(swap1.pool_registry_pubkey.clone()),
+        //use the same mint as the right side of swap1
+        &token_b_mint_key,
+        &token_c_mint_key,
+        POOL_TOKEN_B2_AMOUNT,
+        POOL_TOKEN_C_AMOUNT,
+    )
+    .await;
+    swap2
+        .initialize_swap(&mut banks_client, &payer, &recent_blockhash)
+        .await
+        .unwrap();
+
+    //setup our users token account, owned and paid for by user
+    let user_token_a = Keypair::new();
+    helpers::create_token_account(
+        &mut banks_client,
+        &user,
+        &recent_blockhash,
+        &user_token_a,
+        &swap1.token_a_mint_key.pubkey(),
+        &user.pubkey(),
+    )
+    .await
+    .unwrap();
+    //mint tokens to the users account using payer
+    helpers::mint_tokens(
+        &mut banks_client,
+        &payer,
+        &recent_blockhash,
+        &swap1.token_a_mint_key.pubkey(),
+        &user_token_a.pubkey(),
+        &payer,
+        USER_TOKEN_A_BAL,
+    )
+    .await
+    .unwrap();
+
+    //simple swap should work
+    swap1
+        .routed_swap(
+            &mut banks_client,
+            &user,
+            &recent_blockhash,
+            &swap2,
+            &user_token_a.pubkey(),
+            None,
+            None,
+            USER_WILL_SWAP,
+            0, //not testing exacts, just testing fee paying
+        )
+        .await
+        .unwrap();
+
+    let fee_bal = helpers::get_token_balance(&mut banks_client, &swap1.pool_fee_key.pubkey()).await;
+    assert!(fee_bal > 0);
+
+    //empty the fee account
+    helpers::burn_tokens(
+        &mut banks_client,
+        &payer,
+        &recent_blockhash,
+        &swap1.pool_mint_key.pubkey(),
+        &swap1.pool_fee_key.pubkey(),
+        &payer,
+        fee_bal,
+    )
+    .await
+    .unwrap();
+
+    //pull a G and close the fee token account
+    helpers::close_token_account(
+        &mut banks_client, 
+        &payer, 
+        &recent_blockhash, 
+        &swap1.pool_fee_key.pubkey(), 
+        &payer,
+    )
+    .await
+    .unwrap();
+
+    //simple swap should still work, because we now ignore missing fee accounts
+    {
+    swap1
+        .routed_swap(
+            &mut banks_client,
+            &user,
+            &recent_blockhash,
+            &swap2,
+            &user_token_a.pubkey(),
+            None,
+            None,
+            USER_WILL_SWAP,
+            0, //not testing exacts, just testing fee paying
+        )
+        .await
+        .unwrap();
+    }
+
+    //assert the fee account still doesnt exist, of course, because G closed it
+    assert!(banks_client.get_account(swap1.pool_fee_key.pubkey()).await.unwrap().is_none());
+    
+    //create the ata for the fee address
+    let ata = helpers::create_associated_token_account(
+        &mut banks_client, 
+        &payer, 
+        &recent_blockhash, 
+        &TEST_OWNER_KEY.parse::<Pubkey>().unwrap(),
+        &swap1.pool_mint_key.pubkey(),
+    )
+    .await
+    .unwrap();
+
+    //repair the swap_pool
+    swap1.repair(
+        &mut banks_client,
+        &user,
+        &recent_blockhash,
+        &ata,
+    )
+    .await
+    .unwrap();
+
+    //verify the token swap account was updated with the new key
+    let swap_account = banks_client.get_account(swap1.swap_pubkey).await.unwrap().unwrap();
+    let swap_account = SwapVersion::unpack(swap_account.data.as_ref()).unwrap();
+    assert!(swap_account.pool_fee_account() == &ata);
+
+    //verify balance of new fee token account is 0 (why the hell it wouldn't be I don't know)
+    let fee_bal = helpers::get_token_balance(&mut banks_client, &ata).await;
+    assert!(fee_bal == 0);
+
+    //simple swap should now pay fee account
+    {
+        swap1
+            .routed_swap(
+                &mut banks_client,
+                &user,
+                &recent_blockhash,
+                &swap2,
+                &user_token_a.pubkey(),
+                None,
+                Some(&user_token_c),
+                USER_WILL_SWAP,
+                0, //not testing exacts, just testing fee paying
+            )
+            .await
+            .unwrap();
+    }
+
+    //verify that fees work again!
+    let fee_bal = helpers::get_token_balance(&mut banks_client, &ata).await;
+    assert!(fee_bal > 0);
+}
+
+#[tokio::test]
+async fn fn_swap_repair_failures() {
+    let user = Keypair::new();
+
+    let mut pt = helpers::program_test();
+    //throw our user account directly onto the chain startup
+    pt.add_account(
+        user.pubkey(),
+        Account::new(100_000_000_000, 0, &system_program::id()),
+    );
+    let (mut banks_client, payer, recent_blockhash) = pt.start().await;
+
+    let token_a_mint_key = Keypair::new();
+    let token_b_mint_key = Keypair::new();
+    let token_c_mint_key = Keypair::new();
+
+    //lp1
+    let mut swap1 = helpers::create_standard_setup(
+        &mut banks_client,
+        &payer,
+        &recent_blockhash,
+        None,
+        &token_a_mint_key,
+        &token_b_mint_key,
+        POOL_TOKEN_A_AMOUNT,
+        POOL_TOKEN_B_AMOUNT,
+    )
+    .await;
+
+    swap1
+        .initialize_swap(&mut banks_client, &payer, &recent_blockhash)
+        .await
+        .unwrap();
+
+    //lp2
+    let mut swap2 = helpers::create_standard_setup(
+        &mut banks_client,
+        &payer,
+        &recent_blockhash,
+        //reuse same registry
+        Some(swap1.pool_registry_pubkey.clone()),
+        //use the same mint as the right side of swap1
+        &token_b_mint_key,
+        &token_c_mint_key,
+        POOL_TOKEN_B2_AMOUNT,
+        POOL_TOKEN_C_AMOUNT,
+    )
+    .await;
+    swap2
+        .initialize_swap(&mut banks_client, &payer, &recent_blockhash)
+        .await
+        .unwrap();
+
+    //setup our users token account, owned and paid for by user
+    let user_token_a = Keypair::new();
+    helpers::create_token_account(
+        &mut banks_client,
+        &user,
+        &recent_blockhash,
+        &user_token_a,
+        &swap1.token_a_mint_key.pubkey(),
+        &user.pubkey(),
+    )
+    .await
+    .unwrap();
+    //mint tokens to the users account using payer
+    helpers::mint_tokens(
+        &mut banks_client,
+        &payer,
+        &recent_blockhash,
+        &swap1.token_a_mint_key.pubkey(),
+        &user_token_a.pubkey(),
+        &payer,
+        USER_TOKEN_A_BAL,
+    )
+    .await
+    .unwrap();
+
+    //simple swap should work
+    swap1
+        .routed_swap(
+            &mut banks_client,
+            &user,
+            &recent_blockhash,
+            &swap2,
+            &user_token_a.pubkey(),
+            None,
+            None,
+            USER_WILL_SWAP,
+            0, //not testing exacts, just testing fee paying
+        )
+        .await
+        .unwrap();
+
+    let fee_bal = helpers::get_token_balance(&mut banks_client, &swap1.pool_fee_key.pubkey()).await;
+    assert!(fee_bal > 0);
+
+    //empty the fee account
+    helpers::burn_tokens(
+        &mut banks_client,
+        &payer,
+        &recent_blockhash,
+        &swap1.pool_mint_key.pubkey(),
+        &swap1.pool_fee_key.pubkey(),
+        &payer,
+        fee_bal,
+    )
+    .await
+    .unwrap();
+
+    let owner = TEST_OWNER_KEY.parse::<Pubkey>().unwrap();
+
+    //create a random user account and try to make it the fee address while the old address exists
+    let k = Keypair::new();
+    helpers::create_token_account(
+        &mut banks_client,
+        &payer,
+        &recent_blockhash,
+        &k,
+        &swap1.pool_mint_key.pubkey(),
+        &user.pubkey(),
+    )
+    .await
+    .unwrap();
+    //fail to repair the swap_pool 
+    {
+        let res = swap1.repair(
+            &mut banks_client,
+            &user,
+            &recent_blockhash,
+            &k.pubkey(),
+        )
+            .await
+            .unwrap_err()
+            .unwrap();
+
+        //invalidinput because old fee address exists
+        assert_eq!(
+            TransactionError::InstructionError(0, InstructionError::Custom(SwapError::InvalidInput as u32)),
+            res);
+    }
+
+    //create an owner account but not ata and try to make the fee address while the old address exists
+    let k = Keypair::new();
+    helpers::create_token_account(
+        &mut banks_client,
+        &payer,
+        &recent_blockhash,
+        &k,
+        &swap1.pool_mint_key.pubkey(),
+        &owner,
+    )
+    .await
+    .unwrap();
+    //fail to repair the swap_pool 
+    {
+        let res = swap1.repair(
+            &mut banks_client,
+            &user,
+            &recent_blockhash,
+            &k.pubkey(),
+        )
+            .await
+            .unwrap_err()
+            .unwrap();
+            
+        //invalidinput because old fee address exists
+        assert_eq!(
+            TransactionError::InstructionError(0, InstructionError::Custom(SwapError::InvalidInput as u32)),
+            res);
+    }
+
+    //pull a G and close the fee token account
+    helpers::close_token_account(
+        &mut banks_client, 
+        &payer, 
+        &recent_blockhash, 
+        &swap1.pool_fee_key.pubkey(), 
+        &payer,
+    )
+    .await
+    .unwrap();
+
+    //simple swap should still work, because we now ignore missing fee accounts
+    {
+    swap1
+        .routed_swap(
+            &mut banks_client,
+            &user,
+            &recent_blockhash,
+            &swap2,
+            &user_token_a.pubkey(),
+            None,
+            None,
+            USER_WILL_SWAP,
+            0, //not testing exacts, just testing fee paying
+        )
+        .await
+        .unwrap();
+    }
+
+    //assert the fee account still doesnt exist, of course, because G closed it
+    assert!(banks_client.get_account(swap1.pool_fee_key.pubkey()).await.unwrap().is_none());
+
+    //create a random user account and try to make it the fee address
+    let k = Keypair::new();
+    helpers::create_token_account(
+        &mut banks_client,
+        &payer,
+        &recent_blockhash,
+        &k,
+        &swap1.pool_mint_key.pubkey(),
+        &user.pubkey(),
+    )
+    .await
+    .unwrap();
+    //fail to repair the swap_pool 
+    {
+        let res = swap1.repair(
+            &mut banks_client,
+            &user,
+            &recent_blockhash,
+            &k.pubkey(),
+        )
+            .await
+            .unwrap_err()
+            .unwrap();
+
+        assert_eq!(
+            TransactionError::InstructionError(0, InstructionError::Custom(SwapError::InvalidOwner as u32)),
+            res);
+    }
+
+    //create an owner account but not ata and try to make the fee address
+    let k = Keypair::new();
+    helpers::create_token_account(
+        &mut banks_client,
+        &payer,
+        &recent_blockhash,
+        &k,
+        &swap1.pool_mint_key.pubkey(),
+        &owner,
+    )
+    .await
+    .unwrap();
+    //fail to repair the swap_pool 
+    {
+        let res = swap1.repair(
+            &mut banks_client,
+            &user,
+            &recent_blockhash,
+            &k.pubkey(),
+        )
+            .await
+            .unwrap_err()
+            .unwrap();
+            
+        assert_eq!(
+            TransactionError::InstructionError(0, InstructionError::Custom(SwapError::IncorrectFeeAccount as u32)),
+            res);
+    }
+    
+    //create the ata for the fee address
+    let ata = helpers::create_associated_token_account(
+        &mut banks_client, 
+        &payer, 
+        &recent_blockhash, 
+        &TEST_OWNER_KEY.parse::<Pubkey>().unwrap(),
+        &swap1.pool_mint_key.pubkey(),
+    )
+    .await
+    .unwrap();
+
+    //pass the valid ata, but a old fee account that is empty but doesn't match whats recorded on swap acct
+    let k = Keypair::new();
+    //fail to repair the swap_pool 
+    {
+        let res = swap1.repair_override_old_fee(
+            &mut banks_client,
+            &user,
+            &recent_blockhash,
+            &ata,
+            Some(k.pubkey()),
+        )
+            .await
+            .unwrap_err()
+            .unwrap();
+            
+        assert_eq!(
+            TransactionError::InstructionError(0, InstructionError::Custom(SwapError::IncorrectFeeAccount as u32)),
+            res);
+    }
+
+    //repair the swap_pool properly
+    swap1.repair(
+        &mut banks_client,
+        &user,
+        &recent_blockhash,
+        &ata,
+    )
+    .await
+    .unwrap();
+
+    //verify the token swap account was updated with the new key
+    let swap_account = banks_client.get_account(swap1.swap_pubkey).await.unwrap().unwrap();
+    let swap_account = SwapVersion::unpack(swap_account.data.as_ref()).unwrap();
+    assert!(swap_account.pool_fee_account() == &ata);
+}

--- a/token-swap/program/tests/swap_repair.rs
+++ b/token-swap/program/tests/swap_repair.rs
@@ -1,4 +1,4 @@
-#![cfg(any(test, feature = "test-bpf"))]
+#![cfg(feature = "test-bpf")]
 
 mod helpers;
 


### PR DESCRIPTION
### Problem
Pool "owner fee" accounts were closed.  We need a way to update the accounts to new ones. 

### Solution
Provide an operation which allows changing a pool's owner fee account to an ATA belonging to the pool owner, only if the existing owner fee account is closed.

### Changes
- added `RepairClosedFeeAccount` operation
- added `solana-program-test` integration tests to confirm behavior and attack the new operation